### PR TITLE
Fix SLF4J

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,9 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
 
     // logging
-    implementation 'org.slf4j:slf4j-api:2.0.1'
-    testImplementation 'ch.qos.logback:logback-core:1.3.1'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.1'
+    compileOnly 'org.slf4j:slf4j-api:2.0.1'
+	testRuntimeOnly 'ch.qos.logback:logback-core:1.3.1'
+	testRuntimeOnly 'ch.qos.logback:logback-classic:1.3.1'
 
     // lombok
     compileOnly 'org.projectlombok:lombok:1.18.24'


### PR DESCRIPTION
downgrade SLF4J to v1 because v2 is too new it is not yet supported by most frameworks.
Currently with v2 (release Aug 2022), this driver won't work on Spring framework.