### PR TITLE
Change required Java version from 19 to 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,5 @@ class Person {
 
 
 ### Minimum Requirements
-- Java 8
+- Java 17
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(19)
+		languageVersion = JavaLanguageVersion.of(17)
 	}
 }
 


### PR DESCRIPTION
This commit f97328af559f2c4027a0158feabbd6a94de9cf64 changes the required Java from 8 to 19. Which I get why we would want to target a newer Java version. However, Java 19 is not an LTS version and you won't find it in big production applications.

Java 17 is cool enough and it is the latest LTS.