### PR TITLE
Better error handling

### DIFF
--- a/src/main/java/com/surrealdb/connection/ErrorToExceptionMapper.java
+++ b/src/main/java/com/surrealdb/connection/ErrorToExceptionMapper.java
@@ -1,0 +1,36 @@
+package com.surrealdb.connection;
+
+import com.surrealdb.connection.exception.SurrealAuthenticationException;
+import com.surrealdb.connection.exception.SurrealException;
+import com.surrealdb.connection.exception.SurrealNoDatabaseSelectedException;
+import com.surrealdb.connection.exception.SurrealRecordAlreadyExitsException;
+import com.surrealdb.connection.model.RpcResponse;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Khalid Alharisi
+ */
+public class ErrorToExceptionMapper {
+    private final static Pattern RECORD_ALREADY_EXITS_PATTERN = Pattern.compile("There was a problem with the database: Database record `(.+):(.+)` already exists");
+
+    public static SurrealException map(RpcResponse.Error error){
+        if (error.getMessage().contains("There was a problem with authentication")) {
+            return new SurrealAuthenticationException();
+        }
+
+        if (error.getMessage().contains("There was a problem with the database: Specify a namespace to use")) {
+            return new SurrealNoDatabaseSelectedException();
+        }
+
+        Matcher recordAlreadyExitsMatcher = RECORD_ALREADY_EXITS_PATTERN.matcher(error.getMessage());
+        if (recordAlreadyExitsMatcher.matches()) {
+            return new SurrealRecordAlreadyExitsException(recordAlreadyExitsMatcher.group(1), recordAlreadyExitsMatcher.group(2));
+        }
+
+        // return the generic Exception
+        return new SurrealException();
+    }
+
+}

--- a/src/main/java/com/surrealdb/connection/ErrorToExceptionMapper.java
+++ b/src/main/java/com/surrealdb/connection/ErrorToExceptionMapper.java
@@ -1,9 +1,6 @@
 package com.surrealdb.connection;
 
-import com.surrealdb.connection.exception.SurrealAuthenticationException;
-import com.surrealdb.connection.exception.SurrealException;
-import com.surrealdb.connection.exception.SurrealNoDatabaseSelectedException;
-import com.surrealdb.connection.exception.SurrealRecordAlreadyExitsException;
+import com.surrealdb.connection.exception.*;
 import com.surrealdb.connection.model.RpcResponse;
 
 import java.util.regex.Matcher;
@@ -14,6 +11,7 @@ import java.util.regex.Pattern;
  */
 public class ErrorToExceptionMapper {
     private final static Pattern RECORD_ALREADY_EXITS_PATTERN = Pattern.compile("There was a problem with the database: Database record `(.+):(.+)` already exists");
+    private final static Pattern UNIQE_INDEX_VIOLATION_PATTERN = Pattern.compile("There was a problem with the database: Database index `(.+)` already contains \\[.+\\], with record `(.+):(.+)`");
 
     public static SurrealException map(RpcResponse.Error error){
         if (error.getMessage().contains("There was a problem with authentication")) {
@@ -27,6 +25,11 @@ public class ErrorToExceptionMapper {
         Matcher recordAlreadyExitsMatcher = RECORD_ALREADY_EXITS_PATTERN.matcher(error.getMessage());
         if (recordAlreadyExitsMatcher.matches()) {
             return new SurrealRecordAlreadyExitsException(recordAlreadyExitsMatcher.group(1), recordAlreadyExitsMatcher.group(2));
+        }
+
+        Matcher uniqueIndexViolationPattern = UNIQE_INDEX_VIOLATION_PATTERN.matcher(error.getMessage());
+        if (uniqueIndexViolationPattern.matches()) {
+            return new UniqueIndexViolationException(uniqueIndexViolationPattern.group(2), uniqueIndexViolationPattern.group(1), uniqueIndexViolationPattern.group(3));
         }
 
         // return the generic Exception

--- a/src/main/java/com/surrealdb/connection/ErrorToExceptionMapper.java
+++ b/src/main/java/com/surrealdb/connection/ErrorToExceptionMapper.java
@@ -30,7 +30,7 @@ public class ErrorToExceptionMapper {
         }
 
         // return the generic Exception
-        return new SurrealException();
+        return new SurrealException(error.getMessage());
     }
 
 }

--- a/src/main/java/com/surrealdb/connection/exception/SurrealException.java
+++ b/src/main/java/com/surrealdb/connection/exception/SurrealException.java
@@ -4,4 +4,11 @@ package com.surrealdb.connection.exception;
  * @author Khalid Alharisi
  */
 public class SurrealException extends RuntimeException {
+
+    public SurrealException() {
+    }
+
+    public SurrealException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/surrealdb/connection/exception/UniqueIndexViolationException.java
+++ b/src/main/java/com/surrealdb/connection/exception/UniqueIndexViolationException.java
@@ -1,0 +1,15 @@
+package com.surrealdb.connection.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author Khalid Alharisi
+ */
+@AllArgsConstructor
+@Getter
+public class UniqueIndexViolationException extends SurrealException {
+    private String tableName;
+    private String indexName;
+    private String recordId;
+}

--- a/src/test/java/com/surrealdb/driver/SurrealDriverTest.java
+++ b/src/test/java/com/surrealdb/driver/SurrealDriverTest.java
@@ -3,6 +3,7 @@ package com.surrealdb.driver;
 import com.surrealdb.connection.SurrealConnection;
 import com.surrealdb.connection.SurrealWebSocketConnection;
 import com.surrealdb.connection.exception.SurrealRecordAlreadyExitsException;
+import com.surrealdb.connection.exception.UniqueIndexViolationException;
 import com.surrealdb.driver.model.PartialPerson;
 import com.surrealdb.driver.model.Person;
 import com.surrealdb.driver.model.QueryResult;
@@ -13,10 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -73,6 +71,18 @@ public class SurrealDriverTest {
             driver.create("person:3", new Person("Engineer", "Khalid", "Alharisi", false));
             driver.create("person:3", new Person("Engineer", "Khalid", "Alharisi", false));
         });
+    }
+
+    @Test
+    public void testCreateAlreadyExistsUsingUniqueIndex() {
+        assertThrows(UniqueIndexViolationException.class, () -> {
+            driver.query("DEFINE INDEX fullNameUniqueIndex ON TABLE person COLUMNS name.first, name.last UNIQUE", Collections.emptyMap(), Object.class);
+            driver.create("person", new Person("Artist", "Mia", "Mcgee", false));
+            driver.create("person", new Person("Artist", "Mia", "Mcgee", false));
+        });
+
+        // cleanup
+        driver.query("REMOVE INDEX fullNameUniqueIndex ON TABLE person", Collections.emptyMap(), Object.class);
     }
 
     @Test


### PR DESCRIPTION
In this PR:
- Move error handling to a separate class because `SurrealWebSocketConnection` is getting big
- Propagate the error message to the `SurrealException` when we don't have a dedicated exception type, so that the user can have an idea about the issue.
- Support unique index violation errors. Solving #10 