### PR TITLE
Replace DTOs with java records

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'org.java-websocket:Java-WebSocket:1.5.3'
 
     // Gson
-    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'com.google.code.gson:gson:2.10.1'
 
     // logging
     implementation 'org.slf4j:slf4j-api:2.0.1'

--- a/src/main/java/com/surrealdb/connection/SurrealWebSocketConnection.java
+++ b/src/main/java/com/surrealdb/connection/SurrealWebSocketConnection.java
@@ -106,8 +106,8 @@ public class SurrealWebSocketConnection extends WebSocketClient implements Surre
     @Override
     public void onMessage(String message) {
         final RpcResponse response = gson.fromJson(message, RpcResponse.class);
-        final String id = response.getId();
-        final RpcResponse.Error error = response.getError();
+        final String id = response.id();
+        final RpcResponse.Error error = response.error();
         final CompletableFuture<Object> callback = (CompletableFuture<Object>) callbacks.get(id);
 
         try {
@@ -117,7 +117,7 @@ public class SurrealWebSocketConnection extends WebSocketClient implements Surre
 
                 if (resultType != null) {
                     Object deserialised = null;
-                    JsonElement responseElement = response.getResult();
+                    JsonElement responseElement = response.result();
                     // The protocol can sometimes send object instead of array when only 1 response is valid
                     if (responseElement.isJsonObject()) {
                         JsonArray jsonArray = new JsonArray(1);
@@ -149,14 +149,14 @@ public class SurrealWebSocketConnection extends WebSocketClient implements Surre
                     callback.complete(null);
                 }
             } else {
-                log.error("Received RPC error: id={} code={} message={}", id, error.getCode(), error.getMessage());
+                log.error("Received RPC error: id={} code={} message={}", id, error.code(), error.message());
 
-                if (error.getMessage().contains("There was a problem with authentication")) {
+                if (error.message().contains("There was a problem with authentication")) {
                     callback.completeExceptionally(new SurrealAuthenticationException());
-                } else if (error.getMessage().contains("There was a problem with the database: Specify a namespace to use")) {
+                } else if (error.message().contains("There was a problem with the database: Specify a namespace to use")) {
                     callback.completeExceptionally(new SurrealNoDatabaseSelectedException());
                 } else {
-                    Matcher recordAlreadyExitsMatcher = RECORD_ALREADY_EXITS_PATTERN.matcher(error.getMessage());
+                    Matcher recordAlreadyExitsMatcher = RECORD_ALREADY_EXITS_PATTERN.matcher(error.message());
                     if (recordAlreadyExitsMatcher.matches()) {
                         callback.completeExceptionally(new SurrealRecordAlreadyExitsException(recordAlreadyExitsMatcher.group(1), recordAlreadyExitsMatcher.group(2)));
                     } else {

--- a/src/main/java/com/surrealdb/connection/SurrealWebSocketConnection.java
+++ b/src/main/java/com/surrealdb/connection/SurrealWebSocketConnection.java
@@ -82,9 +82,9 @@ public class SurrealWebSocketConnection extends WebSocketClient implements Surre
         RpcRequest request = new RpcRequest(lastRequestId.incrementAndGet() + "", method, params);
         CompletableFuture<T> callback = new CompletableFuture<>();
 
-        callbacks.put(request.getId(), callback);
+        callbacks.put(request.id(), callback);
         if (resultType != null) {
-            resultTypes.put(request.getId(), resultType);
+            resultTypes.put(request.id(), resultType);
         }
 
         try {

--- a/src/main/java/com/surrealdb/connection/model/RpcRequest.java
+++ b/src/main/java/com/surrealdb/connection/model/RpcRequest.java
@@ -1,21 +1,8 @@
 package com.surrealdb.connection.model;
 
-import lombok.Getter;
 
-import java.util.UUID;
 
 /**
  * @author Khalid Alharisi
  */
-@Getter
-public class RpcRequest {
-    private final String id;
-    private final String method;
-    private final Object[] params;
-
-    public RpcRequest(String id, String method, Object... params) {
-        this.id = id;
-        this.method = method;
-        this.params = params;
-    }
-}
+public record RpcRequest(String id, String method, Object... params) {}

--- a/src/main/java/com/surrealdb/connection/model/RpcResponse.java
+++ b/src/main/java/com/surrealdb/connection/model/RpcResponse.java
@@ -1,22 +1,10 @@
 package com.surrealdb.connection.model;
 
 import com.google.gson.JsonElement;
-import lombok.Data;
 
 /**
  * @author Khalid Alharisi
  */
-@Data
-public class RpcResponse {
-
-    @Data
-    public static class Error {
-        private int code;
-        private String message;
-    }
-
-    private final String id;
-    private final JsonElement result;
-    private final Error error;
-
+public record RpcResponse(String id, JsonElement result, Error error) {
+    public record Error(int code, String message) {}
 }

--- a/src/main/java/com/surrealdb/driver/model/QueryResult.java
+++ b/src/main/java/com/surrealdb/driver/model/QueryResult.java
@@ -1,15 +1,8 @@
 package com.surrealdb.driver.model;
 
-import lombok.Data;
-
 import java.util.List;
 
 /**
  * @author Khalid Alharisi
  */
-@Data
-public class QueryResult<T> {
-    private List<T> result;
-    private String status;
-    private String time;
-}
+public record QueryResult<T>(List<T> result, String status, String time) {}

--- a/src/main/java/com/surrealdb/driver/model/SignIn.java
+++ b/src/main/java/com/surrealdb/driver/model/SignIn.java
@@ -1,14 +1,7 @@
 package com.surrealdb.driver.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
 /**
  * @author Khalid Alharisi
  */
-@Data
-@AllArgsConstructor
-public class SignIn {
-    private String user;
-    private String pass;
+public record SignIn(String user, String pass) {
 }

--- a/src/main/java/com/surrealdb/driver/model/patch/AddPatch.java
+++ b/src/main/java/com/surrealdb/driver/model/patch/AddPatch.java
@@ -1,19 +1,8 @@
 package com.surrealdb.driver.model.patch;
 
-import lombok.Getter;
-
 /**
  * @author Khalid Alharisi
  */
-@Getter
-public class AddPatch implements Patch {
-    private final String op = "add";
-    private final String path;
-    private final String value;
-
-    public AddPatch(String path, String value) {
-        this.path = path;
-        this.value = value;
-    }
-
+public record AddPatch(String path, String value) implements Patch {
+    private static final String op = "add";
 }

--- a/src/main/java/com/surrealdb/driver/model/patch/ChangePatch.java
+++ b/src/main/java/com/surrealdb/driver/model/patch/ChangePatch.java
@@ -1,19 +1,8 @@
 package com.surrealdb.driver.model.patch;
 
-import lombok.Getter;
-
 /**
  * @author Khalid Alharisi
  */
-@Getter
-public class ChangePatch implements Patch {
-    private final String op = "change";
-    private final String path;
-    private final String value;
-
-    public ChangePatch(String path, String value) {
-        this.path = path;
-        this.value = value;
-    }
-
+public record ChangePatch(String path, String value) implements Patch {
+    private static final String op = "change";
 }

--- a/src/main/java/com/surrealdb/driver/model/patch/RemovePatch.java
+++ b/src/main/java/com/surrealdb/driver/model/patch/RemovePatch.java
@@ -1,17 +1,8 @@
 package com.surrealdb.driver.model.patch;
 
-import lombok.Getter;
-
 /**
  * @author Khalid Alharisi
  */
-@Getter
-public class RemovePatch implements Patch {
-    private final String op = "remove";
-    private final String path;
-
-    public RemovePatch(String path) {
-        this.path = path;
-    }
-
+public record RemovePatch(String path) implements Patch {
+    private static final String op = "remove";
 }

--- a/src/main/java/com/surrealdb/driver/model/patch/ReplacePatch.java
+++ b/src/main/java/com/surrealdb/driver/model/patch/ReplacePatch.java
@@ -1,19 +1,8 @@
 package com.surrealdb.driver.model.patch;
 
-import lombok.Getter;
-
 /**
  * @author Khalid Alharisi
  */
-@Getter
-public class ReplacePatch implements Patch {
-    private final String op = "replace";
-    private final String path;
-    private final String value;
-
-    public ReplacePatch(String path, String value) {
-        this.path = path;
-        this.value = value;
-    }
-
+public record ReplacePatch(String path, String value) implements Patch {
+    private static final String op = "replace";
 }

--- a/src/test/java/com/surrealdb/driver/SurrealDriverTest.java
+++ b/src/test/java/com/surrealdb/driver/SurrealDriverTest.java
@@ -82,8 +82,8 @@ public class SurrealDriverTest {
         List<QueryResult<Person>> actual = driver.query("select * from person where name.first = $firstName", args, Person.class);
 
         assertEquals(1, actual.size()); // number of queries
-        assertEquals("OK", actual.get(0).getStatus()); // first query executed successfully
-        assertEquals(1, actual.get(0).getResult().size()); // number of rows returned
+        assertEquals("OK", actual.get(0).status()); // first query executed successfully
+        assertEquals(1, actual.get(0).result().size()); // number of rows returned
     }
 
     @Test


### PR DESCRIPTION
Please consider this simple refactoring PR:

1. Replaces the use of the java DTO with logbook pattern with the new immutable Java Records instances.
2. Upgrades Gson to a newer version supporting Java Records when marshalling the response.
3. A fair bit of simple boilerplate code removed.
4. It possibly removes the need for the Lombok dependency.
5. Current unit tests all green.