### PR TITLE
Use test containers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,9 @@ on:
   pull_request:
 
 jobs:
-
   test:
     runs-on: ubuntu-latest
     steps:
-
-      - name: Setup SurrealDB
-        run: docker run -d --rm -p 8000:8000 surrealdb/surrealdb:latest start --user=root --pass=root
-
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,9 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Run Tests
         uses: gradle/gradle-build-action@v2

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ ext {
 	logbackVersion = "1.3.1"
 	lombokVersion = "1.18.26"
 	junitVersion = "5.8.1"
+    testcontainersVersion = "1.17.6"
 }
 
 dependencies {
@@ -46,8 +47,8 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
-    testImplementation "org.testcontainers:testcontainers:1.17.6"
-    testImplementation "org.testcontainers:junit-jupiter:1.17.6"
+    testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
+    testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
     // junit
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
+    testImplementation "org.testcontainers:testcontainers:1.17.6"
+    testImplementation "org.testcontainers:junit-jupiter:1.17.6"
+
 }
 
 test {

--- a/src/test/java/com/surrealdb/connection/SurrealConnectionTest.java
+++ b/src/test/java/com/surrealdb/connection/SurrealConnectionTest.java
@@ -3,8 +3,12 @@ package com.surrealdb.connection;
 import com.surrealdb.connection.exception.SurrealConnectionTimeoutException;
 import com.surrealdb.connection.exception.SurrealNotConnectedException;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import com.surrealdb.TestUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -13,12 +17,22 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author Khalid Alharisi
  */
 @Slf4j
+@Testcontainers
 public class SurrealConnectionTest {
+
+    @Container
+    private static final GenericContainer surrealDb = new GenericContainer(DockerImageName.parse("surrealdb/surrealdb:latest"))
+        .withExposedPorts(8000).withCommand("start --log trace --user root --pass root memory");
+    private SurrealWebSocketConnection connection;
+
+    @BeforeEach
+    public void setUp() {
+        connection = new SurrealWebSocketConnection(surrealDb.getHost(), surrealDb.getFirstMappedPort(), false);
+    }
 
     @Test
     public void testConnectSuccessfully() {
         assertDoesNotThrow(() -> {
-            SurrealConnection connection = new SurrealWebSocketConnection(TestUtils.getHost(), TestUtils.getPort(), false);
             connection.connect(3);
         });
     }
@@ -50,7 +64,6 @@ public class SurrealConnectionTest {
     @Test
     public void testUserForgotToConnect() {
         assertThrows(SurrealNotConnectedException.class, () -> {
-            SurrealConnection connection = new SurrealWebSocketConnection(TestUtils.getHost(), TestUtils.getPort(), false);
             connection.rpc(null, "let", "some_key", "some_val");
         });
     }
@@ -58,7 +71,6 @@ public class SurrealConnectionTest {
     @Test
     public void testUserConnectsThenDisconnects() {
         assertThrows(SurrealNotConnectedException.class, () -> {
-            SurrealConnection connection = new SurrealWebSocketConnection(TestUtils.getHost(), TestUtils.getPort(), false);
             connection.connect(3);
             connection.disconnect();
             connection.rpc(null, "let", "some_key", "some_val");

--- a/src/test/java/com/surrealdb/connection/SurrealConnectionTest.java
+++ b/src/test/java/com/surrealdb/connection/SurrealConnectionTest.java
@@ -32,9 +32,7 @@ public class SurrealConnectionTest {
 
     @Test
     public void testConnectSuccessfully() {
-        assertDoesNotThrow(() -> {
-            connection.connect(3);
-        });
+        assertDoesNotThrow(() -> connection.connect(3));
     }
 
     @Test
@@ -63,9 +61,7 @@ public class SurrealConnectionTest {
 
     @Test
     public void testUserForgotToConnect() {
-        assertThrows(SurrealNotConnectedException.class, () -> {
-            connection.rpc(null, "let", "some_key", "some_val");
-        });
+        assertThrows(SurrealNotConnectedException.class, () -> connection.rpc(null, "let", "some_key", "some_val"));
     }
 
     @Test

--- a/src/test/java/com/surrealdb/driver/SurrealDriverSpecialOperationsTest.java
+++ b/src/test/java/com/surrealdb/driver/SurrealDriverSpecialOperationsTest.java
@@ -22,12 +22,11 @@ public class SurrealDriverSpecialOperationsTest {
     @Container
     private static final GenericContainer surrealDb = new GenericContainer(DockerImageName.parse("surrealdb/surrealdb:latest"))
         .withExposedPorts(8000).withCommand("start --log trace --user root --pass root memory");
-    private SurrealWebSocketConnection connection;
     private SyncSurrealDriver driver;
 
     @BeforeEach
     public void setup(){
-        connection = new SurrealWebSocketConnection(surrealDb.getHost(), surrealDb.getFirstMappedPort(), false);
+        SurrealWebSocketConnection connection = new SurrealWebSocketConnection(surrealDb.getHost(), surrealDb.getFirstMappedPort(), false);
         connection.connect(5);
         driver = new SyncSurrealDriver(connection);
     }
@@ -39,9 +38,7 @@ public class SurrealDriverSpecialOperationsTest {
 
     @Test
     public void testBadCredentials() {
-        assertThrows(SurrealAuthenticationException.class, () -> {
-            driver.signIn("admin", "incorrect-password");
-        });
+        assertThrows(SurrealAuthenticationException.class, () -> driver.signIn("admin", "incorrect-password"));
     }
 
     @Test

--- a/src/test/java/com/surrealdb/driver/SurrealDriverSpecialOperationsTest.java
+++ b/src/test/java/com/surrealdb/driver/SurrealDriverSpecialOperationsTest.java
@@ -1,26 +1,33 @@
 package com.surrealdb.driver;
 
-import com.surrealdb.connection.SurrealConnection;
+import com.surrealdb.TestUtils;
 import com.surrealdb.connection.SurrealWebSocketConnection;
 import com.surrealdb.connection.exception.SurrealAuthenticationException;
 import com.surrealdb.connection.exception.SurrealNoDatabaseSelectedException;
 import com.surrealdb.driver.model.Person;
-import com.surrealdb.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Khalid Alharisi
  */
+@Testcontainers
 public class SurrealDriverSpecialOperationsTest {
-
+    @Container
+    private static final GenericContainer surrealDb = new GenericContainer(DockerImageName.parse("surrealdb/surrealdb:latest"))
+        .withExposedPorts(8000).withCommand("start --log trace --user root --pass root memory");
+    private SurrealWebSocketConnection connection;
     private SyncSurrealDriver driver;
 
     @BeforeEach
     public void setup(){
-        SurrealConnection connection = new SurrealWebSocketConnection(TestUtils.getHost(), TestUtils.getPort(), false);
+        connection = new SurrealWebSocketConnection(surrealDb.getHost(), surrealDb.getFirstMappedPort(), false);
         connection.connect(5);
         driver = new SyncSurrealDriver(connection);
     }

--- a/src/test/java/com/surrealdb/driver/SurrealDriverTest.java
+++ b/src/test/java/com/surrealdb/driver/SurrealDriverTest.java
@@ -31,12 +31,11 @@ public class SurrealDriverTest {
     @Container
     private static final GenericContainer surrealDb = new GenericContainer(DockerImageName.parse("surrealdb/surrealdb:latest"))
         .withExposedPorts(8000).withCommand("start --log trace --user root --pass root memory");
-    private SurrealWebSocketConnection connection;
     private SyncSurrealDriver driver;
 
     @BeforeEach
     public void setup() {
-        connection = new SurrealWebSocketConnection(surrealDb.getHost(), surrealDb.getFirstMappedPort(), false);
+        SurrealWebSocketConnection connection = new SurrealWebSocketConnection(surrealDb.getHost(), surrealDb.getFirstMappedPort(), false);
         connection.connect(5);
 
         driver = new SyncSurrealDriver(connection);
@@ -125,9 +124,7 @@ public class SurrealDriverTest {
         List<Person> actual = driver.update("person", expected);
 
         assertEquals(2, actual.size());
-        actual.forEach(person -> {
-            assertEquals(expected.getTitle(), person.getTitle());
-        });
+        actual.forEach(person -> assertEquals(expected.getTitle(), person.getTitle()));
     }
 
     @Test
@@ -147,9 +144,7 @@ public class SurrealDriverTest {
         List<Person> actual = driver.change("person", patch, Person.class);
 
         assertEquals(2, actual.size());
-        actual.forEach(person -> {
-            assertEquals(patch.isMarketing(), person.isMarketing());
-        });
+        actual.forEach(person -> assertEquals(patch.isMarketing(), person.isMarketing()));
     }
 
     @Test

--- a/src/test/java/com/surrealdb/driver/SurrealDriverTest.java
+++ b/src/test/java/com/surrealdb/driver/SurrealDriverTest.java
@@ -1,6 +1,6 @@
 package com.surrealdb.driver;
 
-import com.surrealdb.connection.SurrealConnection;
+import com.surrealdb.TestUtils;
 import com.surrealdb.connection.SurrealWebSocketConnection;
 import com.surrealdb.connection.exception.SurrealRecordAlreadyExitsException;
 import com.surrealdb.driver.model.PartialPerson;
@@ -8,31 +8,35 @@ import com.surrealdb.driver.model.Person;
 import com.surrealdb.driver.model.QueryResult;
 import com.surrealdb.driver.model.patch.Patch;
 import com.surrealdb.driver.model.patch.ReplacePatch;
-import com.surrealdb.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Khalid Alharisi
  */
+@Testcontainers
 public class SurrealDriverTest {
-
+    @Container
+    private static final GenericContainer surrealDb = new GenericContainer(DockerImageName.parse("surrealdb/surrealdb:latest"))
+        .withExposedPorts(8000).withCommand("start --log trace --user root --pass root memory");
+    private SurrealWebSocketConnection connection;
     private SyncSurrealDriver driver;
 
     @BeforeEach
-    public void setup(){
-        SurrealConnection connection = new SurrealWebSocketConnection(TestUtils.getHost(), TestUtils.getPort(), false);
+    public void setup() {
+        connection = new SurrealWebSocketConnection(surrealDb.getHost(), surrealDb.getFirstMappedPort(), false);
         connection.connect(5);
 
         driver = new SyncSurrealDriver(connection);
@@ -45,7 +49,7 @@ public class SurrealDriverTest {
     }
 
     @AfterEach
-    public void teardown(){
+    public void teardown() {
         driver.delete("person");
     }
 
@@ -151,9 +155,9 @@ public class SurrealDriverTest {
     @Test
     public void testPatchOne() {
         List<Patch> patches = Arrays.asList(
-                new ReplacePatch("/name/first", "Khalid"),
-                new ReplacePatch("/name/last", "Alharisi"),
-                new ReplacePatch("/title", "Engineer")
+            new ReplacePatch("/name/first", "Khalid"),
+            new ReplacePatch("/name/last", "Alharisi"),
+            new ReplacePatch("/title", "Engineer")
         );
 
         driver.patch("person:1", patches);
@@ -168,9 +172,9 @@ public class SurrealDriverTest {
     @Test
     public void testPatchAll() {
         List<Patch> patches = Arrays.asList(
-                new ReplacePatch("/name/first", "Khalid"),
-                new ReplacePatch("/name/last", "Alharisi"),
-                new ReplacePatch("/title", "Engineer")
+            new ReplacePatch("/name/first", "Khalid"),
+            new ReplacePatch("/name/last", "Alharisi"),
+            new ReplacePatch("/title", "Engineer")
         );
 
         driver.patch("person", patches);

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
 


### PR DESCRIPTION
This PR replaces the hardcoded local references to a local running surrealDB instance.

See https://www.testcontainers.org for more information about test containers.

If you monitor your docker daemon while the tests run you'll see it spin up surrealdb for a few seconds before removing it.