### PR TITLE
Fix gradle dep to exclude old slf4j and force slf4j-api:2.0.1 to be used for jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ java {
 }
 
 ext {
+    slf4jVersion = "2.0.1"
 	logbackVersion = "1.3.1"
 	lombokVersion = "1.18.26"
 	junitVersion = "5.8.1"
@@ -34,7 +35,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
 
     // logging
-    implementation 'org.slf4j:slf4j-api:2.0.1'
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
     testRuntimeOnly "ch.qos.logback:logback-core:${logbackVersion}"
     testRuntimeOnly "ch.qos.logback:logback-classic:${logbackVersion}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
 
     // logging
-    compileOnly 'org.slf4j:slf4j-api:2.0.1'
+    implementation 'org.slf4j:slf4j-api:2.0.1'
     testRuntimeOnly "ch.qos.logback:logback-core:${logbackVersion}"
     testRuntimeOnly "ch.qos.logback:logback-classic:${logbackVersion}"
 


### PR DESCRIPTION
This PR forces slf4j-api:2.0.1 to be used for jar else it pulls in a 1.7.X version from the websocket dependency.

https://github.com/surrealdb/surrealdb.java/issues/27 shows that an old version of slf4j is being bundled by the surrealdb driver see https://www.slf4j.org/codes.html#multiple_bindings