### PR TITLE
Fix JSON Object deserialization.

### DIFF
--- a/src/main/java/com/surrealdb/connection/SurrealWebSocketConnection.java
+++ b/src/main/java/com/surrealdb/connection/SurrealWebSocketConnection.java
@@ -115,9 +115,7 @@ public class SurrealWebSocketConnection extends WebSocketClient implements Surre
                     JsonElement responseElement = response.getResult();
                     // The protocol can sometimes send object instead of array when only 1 response is valid
                     if (responseElement.isJsonObject()) {
-                        JsonArray jsonArray = new JsonArray(1);
-                        jsonArray.add(responseElement);
-                        deserialised = gson.fromJson(jsonArray, resultType);
+                        deserialised = gson.fromJson(responseElement, resultType);
                     } else if (responseElement.isJsonArray()) {
                         JsonArray jsonArray = responseElement.getAsJsonArray();
                         deserialised = gson.fromJson(jsonArray, resultType);


### PR DESCRIPTION
Fixed JSON Object deserialization in SurrealWebSocketConnection. Errors occurred when trying to create/select/update/etc a database record with a specified ID, see more [here](https://github.com/surrealdb/surrealdb.java/issues/43).
This fixes those errors occurring, but after some testing, I encountered other problems such as: when trying to select a record with a specified ID, it would just return an empty Array.

**Overall more testing and fixing need to be done for other parts of the code.**

If there is any confusion, just ask me.
Thanks to @phughk for the explanations and help!