### PR TITLE
chore(#50): change the build action target to integrationTest 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test
+          arguments: integrationTest
 
       - name: Build
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: integrationTest
+          arguments: test integrationTest
 
       - name: Build
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
from test as unit tests do not provide sufficient coverage.  Note that this will fail quality checks as the build has a failed test.