### PR TITLE
Add environment variables for test override

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ class Person {
 }
 ```
 
+### Developing
+You can build the project with `./gradlew build`.
+Unit tests are run with `./gradlew test`.
+Integration tests are run with `./gradlew integrationTest`.
+Integration tests depend on having docker installed.
+
+The following environment variables can be used to avoid relying on docker.
+
+| ENV | Description |
+|--|--|
+| SURREALDB_JAVA_HOST | The host address of SurrealDB |
+| SURREALDB_JAVA_PORT | The port address of SurrealDB |
+
 ### Planned Features
 - A complete SDK With Repository pattern.
 - JDBC interface (work in progress can be found in `src/main/java/com/surrealdb/jdbc`)

--- a/src/intTest/java/com/surrealdb/TestEnvVars.java
+++ b/src/intTest/java/com/surrealdb/TestEnvVars.java
@@ -1,0 +1,9 @@
+package com.surrealdb;
+
+/**
+ * TestEnvVars are static strings of environment variables that can be declared to modify test behaviour
+ */
+public class TestEnvVars {
+    public static final String SURREALDB_JAVA_HOST = "SURREALDB_JAVA_HOST";
+    public static final String SURREALDB_JAVA_PORT = "SURREALDB_JAVA_PORT";
+}


### PR DESCRIPTION
Add environment variables for test override.
This is useful for example, when you want to test against a local instance of docker instead of a container.
Documented in README