### PR TITLE
Introduce shared base class for integration tests

### DIFF
--- a/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
+++ b/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
@@ -1,0 +1,47 @@
+package com.surrealdb;
+
+import com.surrealdb.connection.SurrealWebSocketConnection;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Optional;
+
+public class BaseIntegrationTest {
+    private static Optional<GenericContainer> container = Optional.empty();
+
+    protected static String testHost;
+    protected static int testPort;
+
+    @BeforeAll
+    public static void create_connection() {
+        // Check if both host and port have been decalred as environment variable overrides
+        Optional<String> envHost = Optional.ofNullable(System.getenv(TestEnvVars.SURREALDB_JAVA_HOST)).filter(str -> !str.isBlank());
+        Optional<Integer> envPort = Optional.ofNullable(System.getenv(TestEnvVars.SURREALDB_JAVA_PORT)).map(strPort -> {
+            try {
+                return Integer.parseInt(strPort);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        });
+        // if they have then use that address instead
+        if (envHost.isPresent() && envPort.isPresent()) {
+            testHost = envHost.get();
+            testPort = envPort.get();
+        } else {
+            // No env vars, start a container
+            container = Optional.of(new GenericContainer(DockerImageName.parse("surrealdb/surrealdb:latest"))
+                .withExposedPorts(8000).withCommand("start --log trace --user root --pass root memory"));
+            container.get().start();
+            testHost = container.get().getHost();
+            testPort = container.get().getFirstMappedPort();
+        }
+    }
+
+    @AfterAll
+    public static void teardown_connection() {
+        container.ifPresent(GenericContainer::stop);
+    }
+
+}

--- a/src/intTest/java/com/surrealdb/driver/SurrealDriverSpecialOperationsTest.java
+++ b/src/intTest/java/com/surrealdb/driver/SurrealDriverSpecialOperationsTest.java
@@ -2,6 +2,7 @@ package com.surrealdb.driver;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.surrealdb.BaseIntegrationTest;
 import com.surrealdb.TestUtils;
 import com.surrealdb.connection.SurrealWebSocketConnection;
 import com.surrealdb.connection.exception.SurrealAuthenticationException;
@@ -18,21 +19,13 @@ import org.testcontainers.utility.DockerImageName;
  * @author Khalid Alharisi
  */
 @Testcontainers
-public class SurrealDriverSpecialOperationsTest {
-    @Container
-    @SuppressWarnings("rawtypes")
-    private static final GenericContainer SURREAL_DB =
-            new GenericContainer(DockerImageName.parse("surrealdb/surrealdb:latest"))
-                    .withExposedPorts(8000)
-                    .withCommand("start --log trace --user root --pass root memory");
+public class SurrealDriverSpecialOperationsTest extends BaseIntegrationTest {
 
     private SyncSurrealDriver driver;
 
     @BeforeEach
     public void setup() {
-        SurrealWebSocketConnection connection =
-                new SurrealWebSocketConnection(
-                        SURREAL_DB.getHost(), SURREAL_DB.getFirstMappedPort(), false);
+        SurrealWebSocketConnection connection = new SurrealWebSocketConnection(testHost, testPort, false);
         connection.connect(5);
         driver = new SyncSurrealDriver(connection);
     }

--- a/src/intTest/java/com/surrealdb/driver/SurrealDriverTest.java
+++ b/src/intTest/java/com/surrealdb/driver/SurrealDriverTest.java
@@ -1,5 +1,6 @@
 package com.surrealdb.driver;
 
+import com.surrealdb.BaseIntegrationTest;
 import com.surrealdb.TestUtils;
 import com.surrealdb.connection.SurrealWebSocketConnection;
 import com.surrealdb.connection.exception.SurrealRecordAlreadyExitsException;
@@ -39,17 +40,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author Khalid Alharisi
  */
 @Testcontainers
-public class SurrealDriverTest {
-    @Container
-    private static final GenericContainer SURREAL_DB = new GenericContainer(DockerImageName.parse("surrealdb/surrealdb:latest"))
-        .withExposedPorts(8000).withCommand("start --log trace --user root --pass root memory");
+public class SurrealDriverTest extends BaseIntegrationTest {
     private SyncSurrealDriver driver;
+    private boolean connected = false;
 
     @BeforeEach
     public void setup() {
-        SurrealWebSocketConnection connection = new SurrealWebSocketConnection(SURREAL_DB.getHost(), SURREAL_DB.getFirstMappedPort(), false);
+        SurrealWebSocketConnection connection = new SurrealWebSocketConnection(testHost, testPort, false);
         connection.connect(5);
-
         driver = new SyncSurrealDriver(connection);
 
         driver.signIn(TestUtils.getUsername(), TestUtils.getPassword());


### PR DESCRIPTION
Introduce a base class that can be shared between integration tests.
This base class handles either environment variable configuration (local binary, remote binary) or test containers (requires docker).