### PR TITLE
New API proposal

### DIFF
--- a/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
+++ b/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 
 public class BaseIntegrationTest {
@@ -37,6 +39,38 @@ public class BaseIntegrationTest {
             testHost = container.get().getHost();
             testPort = container.get().getFirstMappedPort();
         }
+    }
+
+    /**
+     * If the connection is http, this will return the http URI
+     * @return the URI or empty if it isnt http
+     */
+    protected Optional<URI> getHttp() {
+        if (container.isPresent()) {
+            return Optional.of(URI.create("http://" + testHost + ":" + testPort));
+        }
+        if (testHost.startsWith("http")) {
+            try {
+                new URI(testHost + ":" + testPort);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    protected Optional<URI> getWebSocketConnection() {
+        if (container.isPresent()) {
+            return Optional.of(URI.create("ws://" + testHost + ":" + testPort));
+        }
+        if (testHost.startsWith("ws://") || testHost.startsWith("wss://")) {
+            try {
+                new URI(testHost + ":" + testPort);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Optional.empty();
     }
 
     @AfterAll

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -1,0 +1,63 @@
+package com.surrealdb.refactor;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.surrealdb.BaseIntegrationTest;
+import com.surrealdb.refactor.driver.BidirectionalSurrealDB;
+import com.surrealdb.refactor.driver.StatelessSurrealDB;
+import com.surrealdb.refactor.driver.SurrealDBFactory;
+import com.surrealdb.refactor.driver.UnauthenticatedSurrealDB;
+import com.surrealdb.refactor.types.Credentials;
+import com.surrealdb.refactor.types.Param;
+import com.surrealdb.refactor.types.Value;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DemoScenarioTest extends BaseIntegrationTest {
+    @Test
+    public void testDemoScenario() throws Exception {
+        // Setup
+        URI address = getHttp().orElseThrow(() -> new IllegalStateException("No HTTP server configured"));
+        UnauthenticatedSurrealDB<BidirectionalSurrealDB> unauthenticated = new SurrealDBFactory().connectBidirectional(address);
+
+        // Authenticate
+        BidirectionalSurrealDB surrealDB = unauthenticated.authenticate(new Credentials("admin", "admin"));
+
+        // Create a multi-statement query
+        StringBuilder query = new StringBuilder("INSERT person:lamport VALUES {'name': 'leslie'};\n");
+        query.append("UPDATE $whichPerson SET year=$year;\n");
+        query.append("DELETE person:lamport;");
+
+        // Create the list of parameters used in the query
+        List<Param> params = List.of(
+            new Param("whichPerson", Value.fromJson(new JsonPrimitive("person:lamport"))),
+            new Param("year", Value.fromJson(new JsonPrimitive(2013)))
+        );
+
+        // Execute the query
+        List<Value> results = surrealDB.query(query.toString(), params);
+
+        // Validate the results of the multi-statement query
+        assertEquals(results.size(), 3);
+        assertEquals(results.get(0).intoJson(), asJson(Tuple.of("name", new JsonPrimitive("leslie")), Tuple.of("id", new JsonPrimitive("person:lamport"))));
+        assertEquals(results.get(1).intoJson(), asJson(Tuple.of("name", new JsonPrimitive("leslie")), Tuple.of("id", new JsonPrimitive("person:lamport"))));
+    }
+
+
+    //----------------------------------------------------------------
+    // Helpers below this point
+
+    private static JsonObject asJson(Tuple<String, JsonElement>... data) {
+        JsonObject obj = new JsonObject();
+        for (Tuple<String, JsonElement> entry: data) {
+            obj.add(entry.key, entry.value);
+        }
+        return obj;
+    }
+}
+

--- a/src/intTest/java/com/surrealdb/refactor/Tuple.java
+++ b/src/intTest/java/com/surrealdb/refactor/Tuple.java
@@ -1,0 +1,15 @@
+package com.surrealdb.refactor;
+
+public class Tuple<K, V> {
+    final K key;
+    final V value;
+
+    private Tuple(K key, V value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public static <K, V> Tuple<K, V> of(K key, V value) {
+        return new Tuple<>(key, value);
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/driver/BidirectionalSurrealDB.java
+++ b/src/main/java/com/surrealdb/refactor/driver/BidirectionalSurrealDB.java
@@ -1,0 +1,7 @@
+package com.surrealdb.refactor.driver;
+
+/**
+ * Bidirectional driver.
+ */
+public interface BidirectionalSurrealDB extends StatelessSurrealDB {
+}

--- a/src/main/java/com/surrealdb/refactor/driver/HttpConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/HttpConnection.java
@@ -1,0 +1,35 @@
+package com.surrealdb.refactor.driver;
+
+import com.surrealdb.refactor.exception.InvalidAddressException;
+import com.surrealdb.refactor.exception.InvalidAddressExceptionCause;
+import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
+import com.surrealdb.refactor.types.Credentials;
+import com.surrealdb.refactor.types.Param;
+import com.surrealdb.refactor.types.Value;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+public class HttpConnection {
+    public static UnauthenticatedSurrealDB<StatelessSurrealDB> connect(URI uri) {
+        List<String> allowed = Arrays.asList("http", "https");
+        if (!allowed.contains(uri.getScheme().toLowerCase().trim())) {
+            throw new InvalidAddressException(uri, InvalidAddressExceptionCause.INVALID_SCHEME, "Only http and https are supported schemes");
+        }
+
+        return new UnauthenticatedSurrealDB<StatelessSurrealDB>() {
+            @Override
+            public StatelessSurrealDB authenticate(Credentials credentials) {
+                return new StatelessSurrealDB() {
+                    @Override
+                    public List<Value> query(String query, List<Param> params) {
+                        throw SurrealDBUnimplementedException.withTicket("TODO no ticket yet").withMessage("HTTP connections are not yet implemented");
+                    }
+
+                };
+            }
+        };
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/driver/StatelessSurrealDB.java
+++ b/src/main/java/com/surrealdb/refactor/driver/StatelessSurrealDB.java
@@ -1,0 +1,18 @@
+package com.surrealdb.refactor.driver;
+
+import com.surrealdb.refactor.types.Param;
+import com.surrealdb.refactor.types.Value;
+
+import java.util.List;
+
+/**
+ * StatelessSurrealDB is the baseline interface available for all SurrealDB instances.
+ */
+public interface StatelessSurrealDB {
+    /**
+     * Perform a general purpose query against the database.
+     * @param query
+     * @return
+     */
+    List<Value> query(String query, List<Param> params);
+}

--- a/src/main/java/com/surrealdb/refactor/driver/SurrealDBFactory.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SurrealDBFactory.java
@@ -1,0 +1,55 @@
+package com.surrealdb.refactor.driver;
+
+import com.surrealdb.refactor.exception.InvalidAddressException;
+import com.surrealdb.refactor.exception.InvalidAddressExceptionCause;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * SurrealDBFactory is the go-to class for creating new SurrealDB driver instances.
+ */
+public class SurrealDBFactory {
+
+    interface StatelessProvider extends Function<URI, UnauthenticatedSurrealDB<StatelessSurrealDB>> {}
+    interface BidirectionalProvider extends Function<URI, UnauthenticatedSurrealDB<BidirectionalSurrealDB>> {}
+
+    private final Map<String, StatelessProvider> statelessDrivers;
+    private final Map<String, BidirectionalProvider> bidirectionalDrivers;
+
+    public SurrealDBFactory() {
+        this(getDefaultStatelessDrivers(), getDefaultBidirectionalDrivers());
+    }
+
+    public SurrealDBFactory(Map<String, StatelessProvider> statelessDrivers, Map<String, BidirectionalProvider> bidirectionalDrivers) {
+        this.statelessDrivers = statelessDrivers;
+        this.bidirectionalDrivers = bidirectionalDrivers;
+    }
+
+    static Map<String, StatelessProvider> getDefaultStatelessDrivers() {
+        Map<String, StatelessProvider> statelessDrivers = new HashMap<>();
+        statelessDrivers.put("http", HttpConnection::connect);
+        statelessDrivers.put("https", HttpConnection::connect);
+        return statelessDrivers;
+    }
+
+    static Map<String, BidirectionalProvider> getDefaultBidirectionalDrivers() {
+        Map<String, BidirectionalProvider> statelessDrivers = new HashMap<>();
+        statelessDrivers.put("ws", WsPlaintextConnection::connect);
+        statelessDrivers.put("wss", WsPlaintextConnection::connect);
+        return statelessDrivers;
+    }
+
+    public UnauthenticatedSurrealDB<StatelessSurrealDB> connectStateless(URI uri) {
+        return statelessDrivers.get(uri.getScheme().toLowerCase().trim()).apply(uri);
+    }
+
+    public UnauthenticatedSurrealDB<BidirectionalSurrealDB> connectBidirectional(URI uri) {
+        return bidirectionalDrivers.get(uri.getScheme().toLowerCase().trim()).apply(uri);
+    }
+
+}

--- a/src/main/java/com/surrealdb/refactor/driver/UnauthenticatedSurrealDB.java
+++ b/src/main/java/com/surrealdb/refactor/driver/UnauthenticatedSurrealDB.java
@@ -1,0 +1,7 @@
+package com.surrealdb.refactor.driver;
+
+import com.surrealdb.refactor.types.Credentials;
+
+public interface UnauthenticatedSurrealDB<DB extends StatelessSurrealDB>{
+    DB authenticate(Credentials credentials);
+}

--- a/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
@@ -1,0 +1,26 @@
+package com.surrealdb.refactor.driver;
+
+import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
+import com.surrealdb.refactor.types.Credentials;
+import com.surrealdb.refactor.types.Param;
+import com.surrealdb.refactor.types.Value;
+
+import java.net.URI;
+import java.util.List;
+
+public class WsPlaintextConnection {
+    public static UnauthenticatedSurrealDB<BidirectionalSurrealDB> connect(URI uri) {
+        return new UnauthenticatedSurrealDB<BidirectionalSurrealDB>() {
+            @Override
+            public BidirectionalSurrealDB authenticate(Credentials credentials) {
+                return new BidirectionalSurrealDB() {
+
+                    @Override
+                    public List<Value> query(String query, List<Param> params) {
+                        throw SurrealDBUnimplementedException.withTicket("TODO create ticket").withMessage("Plaintext websocket connections are not supported yet");
+                    }
+                };
+            }
+        };
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/exception/InvalidAddressException.java
+++ b/src/main/java/com/surrealdb/refactor/exception/InvalidAddressException.java
@@ -1,0 +1,25 @@
+package com.surrealdb.refactor.exception;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class InvalidAddressException extends SurrealDBException {
+
+    private final URI address;
+    private final InvalidAddressExceptionCause causeType;
+
+    public InvalidAddressException(URI address, InvalidAddressExceptionCause causeType, String message) {
+        super(message);
+        this.address = address;
+        this.causeType = causeType;
+    }
+
+    public Optional<URI> getAddress() {
+        return Optional.ofNullable(address);
+    }
+
+    public InvalidAddressExceptionCause getCauseType() {
+        return causeType;
+    }
+}
+

--- a/src/main/java/com/surrealdb/refactor/exception/InvalidAddressExceptionCause.java
+++ b/src/main/java/com/surrealdb/refactor/exception/InvalidAddressExceptionCause.java
@@ -1,0 +1,5 @@
+package com.surrealdb.refactor.exception;
+
+public enum InvalidAddressExceptionCause {
+    INVALID_SCHEME
+}

--- a/src/main/java/com/surrealdb/refactor/exception/SurrealDBException.java
+++ b/src/main/java/com/surrealdb/refactor/exception/SurrealDBException.java
@@ -1,0 +1,10 @@
+package com.surrealdb.refactor.exception;
+
+/**
+ * Baseline exception in the db driver
+ */
+public class SurrealDBException extends RuntimeException {
+    public SurrealDBException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/exception/SurrealDBUnimplementedException.java
+++ b/src/main/java/com/surrealdb/refactor/exception/SurrealDBUnimplementedException.java
@@ -1,0 +1,40 @@
+package com.surrealdb.refactor.exception;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class SurrealDBUnimplementedException extends SurrealDBException {
+
+    private final URL ticketLink;
+    public SurrealDBUnimplementedException(URL ticket, String message) {
+        super(message);
+        ticketLink = ticket;
+    }
+
+    public URL getTicketLink() {
+        return ticketLink;
+    }
+
+    //----------------------------------------------------------------
+    // Builder
+
+    public static WithTicket withTicket(String url) {
+        try {
+            URL ticket = new URL(url);
+            return new WithTicket(ticket);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class WithTicket {
+        private final URL ticket;
+        WithTicket(URL ticket) {
+            this.ticket = ticket;
+        }
+
+        public SurrealDBUnimplementedException withMessage(String message) {
+            return new SurrealDBUnimplementedException(ticket, message);
+        }
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/package-info.java
+++ b/src/main/java/com/surrealdb/refactor/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * @author surrealdb
+ * The refactor package contains the new implementation of the driver.
+ * The goal is to provide clear separation of the following concerns
+ * - protocol (http(s), WebSocket plain text, WebSocket binary), Embedded JNI
+ * - available functionality (realtime capabilities aren't available in stateless protocols like http)
+ * - error handling
+ * - forced authentication
+ * - API compatibility with the Rust driver
+ * - correct lifecycles
+ * - correct types
+ * - simple to navigate, test, and mock
+ *
+ * This change won't be a drop in replacement for the original driver, so treat this as experimental until
+ * it does replace the original implementation.
+ *
+ * This interface is extremely likely to change. Primarily, I don't want to expose internal implementation details.
+ * As I am writing this, I am aware this is happening for a lot of the code.
+ * It will need refactoring to prevent exposing details.
+ */
+package com.surrealdb.refactor;

--- a/src/main/java/com/surrealdb/refactor/types/Credentials.java
+++ b/src/main/java/com/surrealdb/refactor/types/Credentials.java
@@ -1,0 +1,7 @@
+package com.surrealdb.refactor.types;
+
+public class Credentials {
+    public Credentials(String username, String password) {
+
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/types/IntoJson.java
+++ b/src/main/java/com/surrealdb/refactor/types/IntoJson.java
@@ -1,0 +1,8 @@
+package com.surrealdb.refactor.types;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public interface IntoJson {
+    JsonElement intoJson();
+}

--- a/src/main/java/com/surrealdb/refactor/types/Param.java
+++ b/src/main/java/com/surrealdb/refactor/types/Param.java
@@ -1,0 +1,11 @@
+package com.surrealdb.refactor.types;
+
+public class Param {
+    private final String identifier;
+    private final Value value;
+
+    public Param(String identifier, Value value) {
+        this.identifier = identifier;
+        this.value = value;
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/types/Value.java
+++ b/src/main/java/com/surrealdb/refactor/types/Value.java
@@ -1,0 +1,16 @@
+package com.surrealdb.refactor.types;
+
+import com.google.gson.JsonElement;
+import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
+
+public class Value implements IntoJson {
+
+    @Override
+    public JsonElement intoJson() {
+        return null;
+    }
+
+    public static Value fromJson(JsonElement json) {
+        throw SurrealDBUnimplementedException.withTicket("TODO create ticket").withMessage("Parsing general values from JSON is not implemented yet.");
+    }
+}


### PR DESCRIPTION
This is a proposal for a new API for the Java Driver.

The motivation behind this change (gated behind the `com.surrealdb.refactor` package) is:
- Simplify connecting. Currently, it is using a URI only, but it may use configuration in addition to the URI in the future.
- Enforced authentication before using the drivers
- Better error handling with causes and additional information
- Improved separation of concern regarding OOP
- Native SurrealDB types that can be cast
- Separation of protocol and mechanism
- Possibility to choose async or sync (via the Factory, when it is implemented)
- Possibility to add new protocols via injection (such as for embedded)

This PR is not only for review, but also for discussion about the approach. Rust has been a significant influence over this API, more so than most Java APIs, and so enums, builders, interfaces, and generics are favoured.