### PR TITLE
Add signin support to rewrite of websocket protocol

### DIFF
--- a/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
+++ b/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
@@ -1,15 +1,13 @@
 package com.surrealdb;
 
-import com.surrealdb.connection.SurrealWebSocketConnection;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.utility.DockerImageName;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.logging.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 public class BaseIntegrationTest {
     private static Optional<GenericContainer> container = Optional.empty();
@@ -19,10 +17,10 @@ public class BaseIntegrationTest {
 
     @BeforeAll
     public static void set_log_level() {
-//        Logger srdbLog = LogManager.getLogManager();
-//        srdbLog.setLevel(Level.ALL);
+        //        Logger srdbLog = LogManager.getLogManager();
+        //        srdbLog.setLevel(Level.ALL);
         StreamHandler handler = new StreamHandler(System.out, new SimpleFormatter());
-//        srdbLog.addHandler(handler);
+        //        srdbLog.addHandler(handler);
         Logger.getGlobal().setLevel(Level.ALL);
         Logger.getGlobal().addHandler(handler);
     }
@@ -36,8 +34,13 @@ public class BaseIntegrationTest {
             testPort = Env.envPort.get();
         } else {
             // No env vars, start a container
-            container = Optional.of(new GenericContainer(DockerImageName.parse("surrealdb/surrealdb:latest"))
-                .withExposedPorts(8000).withCommand("start --log trace --user root --pass root memory"));
+            container =
+                    Optional.of(
+                            new GenericContainer(
+                                            DockerImageName.parse("surrealdb/surrealdb:latest"))
+                                    .withExposedPorts(8000)
+                                    .withCommand(
+                                            "start --log trace --user root --pass root memory"));
             container.get().start();
             testHost = container.get().getHost();
             testPort = container.get().getFirstMappedPort();
@@ -46,12 +49,15 @@ public class BaseIntegrationTest {
 
     /**
      * If the connection is http, this will return the http URI
+     *
      * @return the URI or empty if it isnt http
      */
     protected Optional<URI> getHttp() {
         // Try env variable
         if (Env.envHost.isPresent() && Env.envPort.isPresent()) {
-            return Optional.of(URI.create(String.format("ws://%s:%d/rpc", Env.envHost.get(), Env.envPort.get())));
+            return Optional.of(
+                    URI.create(
+                            String.format("ws://%s:%d/rpc", Env.envHost.get(), Env.envPort.get())));
         }
         // Fallback to container
         if (container.isPresent()) {
@@ -85,5 +91,4 @@ public class BaseIntegrationTest {
     public static void teardown_connection() {
         container.ifPresent(GenericContainer::stop);
     }
-
 }

--- a/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
+++ b/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
@@ -9,12 +9,23 @@ import org.testcontainers.utility.DockerImageName;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
+import java.util.logging.*;
 
 public class BaseIntegrationTest {
     private static Optional<GenericContainer> container = Optional.empty();
 
     protected static String testHost;
     protected static int testPort;
+
+    @BeforeAll
+    public static void set_log_level() {
+//        Logger srdbLog = LogManager.getLogManager();
+//        srdbLog.setLevel(Level.ALL);
+        StreamHandler handler = new StreamHandler(System.out, new SimpleFormatter());
+//        srdbLog.addHandler(handler);
+        Logger.getGlobal().setLevel(Level.ALL);
+        Logger.getGlobal().addHandler(handler);
+    }
 
     @BeforeAll
     public static void create_connection() {

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -12,11 +12,13 @@ import com.surrealdb.refactor.types.Param;
 import com.surrealdb.refactor.types.Value;
 import java.net.URI;
 import java.util.List;
+
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class DemoScenarioTest extends BaseIntegrationTest {
     @Test
-    //    @Disabled("Functionality is unimplemented, but having the tests shows the design")
+    @Disabled("Functionality is unimplemented, but having the tests shows the design")
     public void testDemoScenario() throws Exception {
         // Setup
         URI address =

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -26,7 +26,7 @@ public class DemoScenarioTest extends BaseIntegrationTest {
         UnauthenticatedSurrealDB<BidirectionalSurrealDB> unauthenticated = new SurrealDBFactory().connectBidirectional(address);
 
         // Authenticate
-        UnusedSurrealDB<BidirectionalSurrealDB> unusedSurrealDB = unauthenticated.authenticate(new Credentials("admin", "admin"));
+        UnusedSurrealDB<BidirectionalSurrealDB> unusedSurrealDB = unauthenticated.authenticate(new Credentials("root", "root"));
 
         // Use namespace, database
         BidirectionalSurrealDB surrealDB = unusedSurrealDB.use("test", "test");

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -1,5 +1,7 @@
 package com.surrealdb.refactor;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
@@ -8,59 +10,65 @@ import com.surrealdb.refactor.driver.*;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
 import com.surrealdb.refactor.types.Value;
-import org.junit.Ignore;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-
 import java.net.URI;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class DemoScenarioTest extends BaseIntegrationTest {
     @Test
-//    @Disabled("Functionality is unimplemented, but having the tests shows the design")
+    //    @Disabled("Functionality is unimplemented, but having the tests shows the design")
     public void testDemoScenario() throws Exception {
         // Setup
-        URI address = getHttp().orElseThrow(() -> new IllegalStateException("No HTTP server configured"));
-        UnauthenticatedSurrealDB<BidirectionalSurrealDB> unauthenticated = new SurrealDBFactory().connectBidirectional(address);
+        URI address =
+                getHttp().orElseThrow(() -> new IllegalStateException("No HTTP server configured"));
+        UnauthenticatedSurrealDB<BidirectionalSurrealDB> unauthenticated =
+                new SurrealDBFactory().connectBidirectional(address);
 
         // Authenticate
-        UnusedSurrealDB<BidirectionalSurrealDB> unusedSurrealDB = unauthenticated.authenticate(new Credentials("root", "root"));
+        UnusedSurrealDB<BidirectionalSurrealDB> unusedSurrealDB =
+                unauthenticated.authenticate(new Credentials("root", "root"));
 
         // Use namespace, database
         BidirectionalSurrealDB surrealDB = unusedSurrealDB.use("test", "test");
 
         // Create a multi-statement query
-        StringBuilder query = new StringBuilder("INSERT person:lamport VALUES {'name': 'leslie'};\n");
+        StringBuilder query =
+                new StringBuilder("INSERT person:lamport VALUES {'name': 'leslie'};\n");
         query.append("UPDATE $whichPerson SET year=$year;\n");
         query.append("DELETE person:lamport;");
 
         // Create the list of parameters used in the query
-        List<Param> params = List.of(
-            new Param("whichPerson", Value.fromJson(new JsonPrimitive("person:lamport"))),
-            new Param("year", Value.fromJson(new JsonPrimitive(2013)))
-        );
+        List<Param> params =
+                List.of(
+                        new Param(
+                                "whichPerson", Value.fromJson(new JsonPrimitive("person:lamport"))),
+                        new Param("year", Value.fromJson(new JsonPrimitive(2013))));
 
         // Execute the query
         List<Value> results = surrealDB.query(query.toString(), params);
 
         // Validate the results of the multi-statement query
         assertEquals(results.size(), 3);
-        assertEquals(results.get(0).intoJson(), asJson(Tuple.of("name", new JsonPrimitive("leslie")), Tuple.of("id", new JsonPrimitive("person:lamport"))));
-        assertEquals(results.get(1).intoJson(), asJson(Tuple.of("name", new JsonPrimitive("leslie")), Tuple.of("id", new JsonPrimitive("person:lamport"))));
+        assertEquals(
+                results.get(0).intoJson(),
+                asJson(
+                        Tuple.of("name", new JsonPrimitive("leslie")),
+                        Tuple.of("id", new JsonPrimitive("person:lamport"))));
+        assertEquals(
+                results.get(1).intoJson(),
+                asJson(
+                        Tuple.of("name", new JsonPrimitive("leslie")),
+                        Tuple.of("id", new JsonPrimitive("person:lamport"))));
     }
 
-
-    //----------------------------------------------------------------
+    // ----------------------------------------------------------------
     // Helpers below this point
 
     private static JsonObject asJson(Tuple<String, JsonElement>... data) {
         JsonObject obj = new JsonObject();
-        for (Tuple<String, JsonElement> entry: data) {
+        for (Tuple<String, JsonElement> entry : data) {
             obj.add(entry.key, entry.value);
         }
         return obj;
     }
 }
-

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -4,10 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.surrealdb.BaseIntegrationTest;
-import com.surrealdb.refactor.driver.BidirectionalSurrealDB;
-import com.surrealdb.refactor.driver.StatelessSurrealDB;
-import com.surrealdb.refactor.driver.SurrealDBFactory;
-import com.surrealdb.refactor.driver.UnauthenticatedSurrealDB;
+import com.surrealdb.refactor.driver.*;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
 import com.surrealdb.refactor.types.Value;
@@ -22,14 +19,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DemoScenarioTest extends BaseIntegrationTest {
     @Test
-    @Disabled("Functionality is unimplemented, but having the tests shows the design")
+//    @Disabled("Functionality is unimplemented, but having the tests shows the design")
     public void testDemoScenario() throws Exception {
         // Setup
         URI address = getHttp().orElseThrow(() -> new IllegalStateException("No HTTP server configured"));
         UnauthenticatedSurrealDB<BidirectionalSurrealDB> unauthenticated = new SurrealDBFactory().connectBidirectional(address);
 
         // Authenticate
-        BidirectionalSurrealDB surrealDB = unauthenticated.authenticate(new Credentials("admin", "admin"));
+        UnusedSurrealDB<BidirectionalSurrealDB> unusedSurrealDB = unauthenticated.authenticate(new Credentials("admin", "admin"));
+
+        // Use namespace, database
+        BidirectionalSurrealDB surrealDB = unusedSurrealDB.use("test", "test");
 
         // Create a multi-statement query
         StringBuilder query = new StringBuilder("INSERT person:lamport VALUES {'name': 'leslie'};\n");

--- a/src/main/java/com/surrealdb/refactor/driver/HttpConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/HttpConnection.java
@@ -21,13 +21,30 @@ public class HttpConnection {
 
         return new UnauthenticatedSurrealDB<StatelessSurrealDB>() {
             @Override
-            public StatelessSurrealDB authenticate(Credentials credentials) {
-                return new StatelessSurrealDB() {
+            public UnusedSurrealDB<StatelessSurrealDB> authenticate(Credentials credentials) {
+                StatelessSurrealDB surrealdb = new StatelessSurrealDB() {
                     @Override
                     public List<Value> query(String query, List<Param> params) {
                         throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/61").withMessage("HTTP connections are not yet implemented");
                     }
 
+                };
+                return new UnusedSurrealDB<>() {
+
+                    @Override
+                    public StatelessSurrealDB use() {
+                        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/67").withMessage("use is not implemented for HTTP");
+                    }
+
+                    @Override
+                    public StatelessSurrealDB use(String namespace) {
+                        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/67").withMessage("use with namespace is not implemented for HTTP");
+                    }
+
+                    @Override
+                    public StatelessSurrealDB use(String namespace, String database) {
+                        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/67").withMessage("use with namespace and database is not implemented for HTTP");
+                    }
                 };
             }
         };

--- a/src/main/java/com/surrealdb/refactor/driver/HttpConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/HttpConnection.java
@@ -6,9 +6,7 @@ import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
 import com.surrealdb.refactor.types.Value;
-
 import java.net.URI;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 
@@ -16,34 +14,45 @@ public class HttpConnection {
     public static UnauthenticatedSurrealDB<StatelessSurrealDB> connect(URI uri) {
         List<String> allowed = Arrays.asList("http", "https");
         if (!allowed.contains(uri.getScheme().toLowerCase().trim())) {
-            throw new InvalidAddressException(uri, InvalidAddressExceptionCause.INVALID_SCHEME, "Only http and https are supported schemes");
+            throw new InvalidAddressException(
+                    uri,
+                    InvalidAddressExceptionCause.INVALID_SCHEME,
+                    "Only http and https are supported schemes");
         }
 
         return new UnauthenticatedSurrealDB<StatelessSurrealDB>() {
             @Override
             public UnusedSurrealDB<StatelessSurrealDB> authenticate(Credentials credentials) {
-                StatelessSurrealDB surrealdb = new StatelessSurrealDB() {
-                    @Override
-                    public List<Value> query(String query, List<Param> params) {
-                        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/61").withMessage("HTTP connections are not yet implemented");
-                    }
-
-                };
+                StatelessSurrealDB surrealdb =
+                        new StatelessSurrealDB() {
+                            @Override
+                            public List<Value> query(String query, List<Param> params) {
+                                throw new SurrealDBUnimplementedException(
+                                        "https://github.com/surrealdb/surrealdb.java/issues/61",
+                                        "HTTP connections are not yet implemented");
+                            }
+                        };
                 return new UnusedSurrealDB<>() {
 
                     @Override
                     public StatelessSurrealDB use() {
-                        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/67").withMessage("use is not implemented for HTTP");
+                        throw new SurrealDBUnimplementedException(
+                                "https://github.com/surrealdb/surrealdb.java/issues/67",
+                                "use is not implemented for HTTP");
                     }
 
                     @Override
                     public StatelessSurrealDB use(String namespace) {
-                        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/67").withMessage("use with namespace is not implemented for HTTP");
+                        throw new SurrealDBUnimplementedException(
+                                "https://github.com/surrealdb/surrealdb.java/issues/67",
+                                "use with namespace is not implemented for HTTP");
                     }
 
                     @Override
                     public StatelessSurrealDB use(String namespace, String database) {
-                        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/67").withMessage("use with namespace and database is not implemented for HTTP");
+                        throw new SurrealDBUnimplementedException(
+                                "https://github.com/surrealdb/surrealdb.java/issues/67",
+                                "use with namespace and database is not implemented for HTTP");
                     }
                 };
             }

--- a/src/main/java/com/surrealdb/refactor/driver/SigninMessage.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SigninMessage.java
@@ -1,9 +1,8 @@
 package com.surrealdb.refactor.driver;
 
-import lombok.Getter;
-
 import java.util.Arrays;
 import java.util.List;
+import lombok.Getter;
 
 @Getter
 public class SigninMessage {
@@ -14,8 +13,6 @@ public class SigninMessage {
 
     public SigninMessage(String requestID, String username, String password) {
         this.id = requestID;
-        this.params = Arrays.asList(
-            new SigninParam(username, password)
-        );
+        this.params = Arrays.asList(new SigninParam(username, password));
     }
 }

--- a/src/main/java/com/surrealdb/refactor/driver/SigninMessage.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SigninMessage.java
@@ -1,0 +1,21 @@
+package com.surrealdb.refactor.driver;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+public class SigninMessage {
+    private final String method = "signin";
+    private final String requestID;
+
+    private final List<SigninParam> params;
+
+    public SigninMessage(String requestID, String username, String password) {
+        this.requestID = requestID;
+        this.params = Arrays.asList(
+            new SigninParam(username, password)
+        );
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/driver/SigninMessage.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SigninMessage.java
@@ -8,12 +8,12 @@ import java.util.List;
 @Getter
 public class SigninMessage {
     private final String method = "signin";
-    private final String requestID;
+    private final String id;
 
     private final List<SigninParam> params;
 
     public SigninMessage(String requestID, String username, String password) {
-        this.requestID = requestID;
+        this.id = requestID;
         this.params = Arrays.asList(
             new SigninParam(username, password)
         );

--- a/src/main/java/com/surrealdb/refactor/driver/SigninParam.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SigninParam.java
@@ -1,0 +1,14 @@
+package com.surrealdb.refactor.driver;
+
+import lombok.Getter;
+
+@Getter
+public class SigninParam {
+    private final String user;
+    private final String pass;
+
+    public SigninParam(String user, String pass) {
+        this.user = user;
+        this.pass = pass;
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientHandler.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientHandler.java
@@ -1,5 +1,9 @@
 package com.surrealdb.refactor.driver;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import io.netty.channel.*;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.websocketx.*;
@@ -7,6 +11,7 @@ import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
 
 import java.net.URI;
+import java.util.UUID;
 
 public class SurrealDBWebsocketClientHandler extends SimpleChannelInboundHandler<Object> {
     private WebSocketClientHandshaker handshaker;
@@ -43,6 +48,12 @@ public class SurrealDBWebsocketClientHandler extends SimpleChannelInboundHandler
             handshaker.finishHandshake(ch, (FullHttpResponse) msg);
             System.out.println("WebSocket Client connected!");
             handshakeFuture.setSuccess();
+            try {
+                String signinMessage = new Gson().toJson(new SigninMessage(UUID.randomUUID().toString(), "root", "root"));
+                ctx.channel().writeAndFlush(new TextWebSocketFrame(signinMessage).content()).sync();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
             return;
         }
 

--- a/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientProtocolHandler.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientProtocolHandler.java
@@ -101,6 +101,9 @@ public class SurrealDBWebsocketClientProtocolHandler
         Promise<Object> promise = channel.eventLoop().newPromise();
         Promise<Object> popped = requestMap.putIfAbsent(requestID, promise);
         if (popped != null) {
+            // Reinsert whatever we removed; This is actually quite problematic, and we should do a
+            // contains check before in case
+            // There will always be race conditions without locks on this
             requestMap.put(requestID, popped);
             throw new UnhandledSurrealDBNettyState(
                     "this should probably be a different error as we know what is happening",

--- a/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientProtocolHandler.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientProtocolHandler.java
@@ -1,23 +1,32 @@
 package com.surrealdb.refactor.driver;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.exception.UnhandledSurrealDBNettyState;
+import com.surrealdb.refactor.types.Credentials;
 import io.netty.channel.*;
-import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.websocketx.*;
-import io.netty.util.CharsetUtil;
-
-import java.net.URI;
+import io.netty.util.concurrent.Promise;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Future;
 import java.util.logging.Logger;
 
-public class SurrealDBWebsocketClientProtocolHandler extends SimpleChannelInboundHandler<TextWebSocketFrame> {
-    private static final Logger log =Logger.getLogger(SurrealDBWebsocketClientProtocolHandler.class.toString());
+public class SurrealDBWebsocketClientProtocolHandler
+        extends SimpleChannelInboundHandler<TextWebSocketFrame> {
+    private static final Logger log =
+            Logger.getLogger(SurrealDBWebsocketClientProtocolHandler.class.toString());
+    private static final String PROPERTY_REQUEST_ID = "id";
     private ChannelPromise handshakeFuture;
+    private final ConcurrentMap<String, Promise<Object>> requestMap = new ConcurrentHashMap();
 
     private Channel channel;
 
-    public SurrealDBWebsocketClientProtocolHandler() {
-    }
+    public SurrealDBWebsocketClientProtocolHandler() {}
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
@@ -38,6 +47,19 @@ public class SurrealDBWebsocketClientProtocolHandler extends SimpleChannelInboun
     protected void channelRead0(ChannelHandlerContext ctx, TextWebSocketFrame msg) {
         Channel ch = ctx.channel();
         System.out.println("Received message: " + msg.text());
+        JsonElement parsed = JsonParser.parseString(msg.text());
+        if (parsed.isJsonObject()) {
+            JsonObject obj = parsed.getAsJsonObject();
+            if (!obj.has(PROPERTY_REQUEST_ID)) {
+                throw new UnhandledSurrealDBNettyState(
+                        "All requests and responses should contain a request id but that isn't enforced by the database; if there is no request id 'id' then the response will not have one either as of this writing",
+                        "Received a message presumed to be a response without a request id");
+            }
+        } else {
+            throw new SurrealDBUnimplementedException(
+                    "https://github.com/surrealdb/surrealdb.java/issues/68",
+                    "JSON array responses are unimplemented in the plaintext websocket protocol");
+        }
     }
 
     @Override
@@ -49,18 +71,42 @@ public class SurrealDBWebsocketClientProtocolHandler extends SimpleChannelInboun
         ctx.close();
     }
 
-    public void signin(SigninMessage signinMessage) {
-        System.out.println("Signin started");
-        if (this.channel==null || !channel.isActive()) {
+    public Future<Object> signin(Credentials credentials) {
+        return signin(UUID.randomUUID().toString(), credentials);
+    }
+
+    public Future<Object> signin(String requestID, Credentials credentials) {
+        // Check if we have an established connection
+        if (channel == null || !channel.isActive()) {
             log.finest("Channel was null or inactive during signin");
-            throw new UnhandledSurrealDBNettyState("We should have a better error for handling this state or perhaps prevent this from happening via the API", "signin failed because channel was either null or inactive");
+            throw new UnhandledSurrealDBNettyState(
+                    "We should have a better error for handling this state or perhaps prevent this from happening via the API",
+                    "signin failed because channel was either null or inactive");
         }
+        // Construct message to be sent
+        SigninMessage signinMessage =
+                new SigninMessage(requestID, credentials.getUsername(), credentials.getPassword());
+        // Handle request response
+        Promise<Object> promise = channel.eventLoop().newPromise();
+        Promise<Object> popped = requestMap.putIfAbsent(requestID, promise);
+        if (popped != null) {
+            requestMap.put(requestID, popped);
+            throw new UnhandledSurrealDBNettyState(
+                    "this should probably be a different error as we know what is happening",
+                    String.format(
+                            "There was an already existing request ID '%s' so unable to perform signin",
+                            requestID));
+        }
+        System.out.println("Signin started");
+        log.finest("Signing in");
         try {
-            log.finest("Signing in");
-            this.channel.writeAndFlush(new TextWebSocketFrame(new Gson().toJson(signinMessage))).sync();
+            channel.writeAndFlush(new TextWebSocketFrame(new Gson().toJson(signinMessage))).sync();
             System.out.println("signin flushed");
         } catch (InterruptedException e) {
-            throw new UnhandledSurrealDBNettyState("We should have a better way of handling these edge cases", "failed to write and flush synchronously during signin");
+            throw new UnhandledSurrealDBNettyState(
+                    "We should have a better way of handling these edge cases",
+                    "failed to write and flush synchronously during signin");
         }
+        return promise;
     }
 }

--- a/src/main/java/com/surrealdb/refactor/driver/UnauthenticatedSurrealDB.java
+++ b/src/main/java/com/surrealdb/refactor/driver/UnauthenticatedSurrealDB.java
@@ -2,6 +2,6 @@ package com.surrealdb.refactor.driver;
 
 import com.surrealdb.refactor.types.Credentials;
 
-public interface UnauthenticatedSurrealDB<DB extends StatelessSurrealDB>{
+public interface UnauthenticatedSurrealDB<DB extends StatelessSurrealDB> {
     UnusedSurrealDB<DB> authenticate(Credentials credentials);
 }

--- a/src/main/java/com/surrealdb/refactor/driver/UnauthenticatedSurrealDB.java
+++ b/src/main/java/com/surrealdb/refactor/driver/UnauthenticatedSurrealDB.java
@@ -3,5 +3,5 @@ package com.surrealdb.refactor.driver;
 import com.surrealdb.refactor.types.Credentials;
 
 public interface UnauthenticatedSurrealDB<DB extends StatelessSurrealDB>{
-    DB authenticate(Credentials credentials);
+    UnusedSurrealDB<DB> authenticate(Credentials credentials);
 }

--- a/src/main/java/com/surrealdb/refactor/driver/UnusedSurrealDB.java
+++ b/src/main/java/com/surrealdb/refactor/driver/UnusedSurrealDB.java
@@ -1,5 +1,11 @@
 package com.surrealdb.refactor.driver;
 
+/**
+ * An API that forces the user to decide whether to use a namespace, database, token or none.
+ * Usually, as a user connects, they need to first authenticate, then configure (such as USE), then they have access.
+ *
+ * @param <DB>
+ */
 public interface UnusedSurrealDB <DB extends StatelessSurrealDB>{
     DB use();
     DB use(String namespace);

--- a/src/main/java/com/surrealdb/refactor/driver/UnusedSurrealDB.java
+++ b/src/main/java/com/surrealdb/refactor/driver/UnusedSurrealDB.java
@@ -2,12 +2,15 @@ package com.surrealdb.refactor.driver;
 
 /**
  * An API that forces the user to decide whether to use a namespace, database, token or none.
- * Usually, as a user connects, they need to first authenticate, then configure (such as USE), then they have access.
+ * Usually, as a user connects, they need to first authenticate, then configure (such as USE), then
+ * they have access.
  *
  * @param <DB>
  */
-public interface UnusedSurrealDB <DB extends StatelessSurrealDB>{
+public interface UnusedSurrealDB<DB extends StatelessSurrealDB> {
     DB use();
+
     DB use(String namespace);
+
     DB use(String namespace, String database);
 }

--- a/src/main/java/com/surrealdb/refactor/driver/UnusedSurrealDB.java
+++ b/src/main/java/com/surrealdb/refactor/driver/UnusedSurrealDB.java
@@ -1,0 +1,7 @@
+package com.surrealdb.refactor.driver;
+
+public interface UnusedSurrealDB <DB extends StatelessSurrealDB>{
+    DB use();
+    DB use(String namespace);
+    DB use(String namespace, String database);
+}

--- a/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
@@ -15,6 +15,9 @@ import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import java.net.URI;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class WsPlaintextConnection {
 
@@ -38,7 +41,13 @@ public class WsPlaintextConnection {
                 SurrealDBWebsocketClientProtocolHandler srdbHandler =
                         (SurrealDBWebsocketClientProtocolHandler)
                                 channel.pipeline().get(HANDLER_ID_SURREALDB_CLIENT);
-                srdbHandler.signin(credentials);
+                Object result;
+                try {
+                    result = srdbHandler.signin(credentials).get(2, TimeUnit.SECONDS);
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    throw new RuntimeException(e);
+                }
+                System.out.printf("Successfully signed in: %s", result);
                 BidirectionalSurrealDB surrealdb =
                         new BidirectionalSurrealDB() {
 

--- a/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
@@ -5,16 +5,19 @@ import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
 import com.surrealdb.refactor.types.Value;
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.List;
 
 public class WsPlaintextConnection {
@@ -26,19 +29,34 @@ public class WsPlaintextConnection {
         try {
             System.out.printf("Connecting to %s\n", uri);
             Channel conn = bootstrapProtocol(uri).connect(uri.getHost(), uri.getPort()).sync().channel();
-            conn.writeAndFlush("This is the message sent").sync();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
 
         return new UnauthenticatedSurrealDB<BidirectionalSurrealDB>() {
             @Override
-            public BidirectionalSurrealDB authenticate(Credentials credentials) {
-                return new BidirectionalSurrealDB() {
+            public UnusedSurrealDB<BidirectionalSurrealDB> authenticate(Credentials credentials) {
+                BidirectionalSurrealDB surrealdb = new BidirectionalSurrealDB() {
 
                     @Override
                     public List<Value> query(String query, List<Param> params) {
                         throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/62").withMessage("Plaintext websocket connections are not supported yet");
+                    }
+                };
+                return new UnusedSurrealDB<>() {
+                    @Override
+                    public BidirectionalSurrealDB use() {
+                        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/66").withMessage("Use for empty arguments is unimplemented");
+                    }
+
+                    @Override
+                    public BidirectionalSurrealDB use(String namespace) {
+                        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/66").withMessage("Use for namespace arguments is unimplemented");
+                    }
+
+                    @Override
+                    public BidirectionalSurrealDB use(String namespace, String database) {
+                        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/66").withMessage("Use for namespace and database arguments is unimplemented");
                     }
                 };
             }
@@ -53,7 +71,6 @@ public class WsPlaintextConnection {
                 protected void initChannel(Channel ch) throws Exception {
                     ChannelPipeline pipeline = ch.pipeline();
                     pipeline.addLast(new HttpClientCodec()).addLast(new HttpObjectAggregator(MAX_CONTENT_LENGTH))
-                        .addLast(new WebSocketClientProtocolHandler(WebSocketClientHandshakerFactory.newHandshaker(uri, WebSocketVersion.V13, null, false, null)))
                         .addLast(new SurrealDBWebsocketClientHandler(uri));
                 }
             });

--- a/src/main/java/com/surrealdb/refactor/exception/InvalidAddressException.java
+++ b/src/main/java/com/surrealdb/refactor/exception/InvalidAddressException.java
@@ -1,8 +1,11 @@
 package com.surrealdb.refactor.exception;
 
+import lombok.ToString;
+
 import java.net.URI;
 import java.util.Optional;
 
+@ToString
 public class InvalidAddressException extends SurrealDBException {
 
     private final URI address;
@@ -22,13 +25,4 @@ public class InvalidAddressException extends SurrealDBException {
         return causeType;
     }
 
-    @Override
-    public String toString() {
-        return "InvalidAddressException{" +
-            "address=" + address +
-            ", causeType=" + causeType +
-            ", message=" + getMessage() +
-            '}';
-    }
 }
-

--- a/src/main/java/com/surrealdb/refactor/exception/InvalidAddressException.java
+++ b/src/main/java/com/surrealdb/refactor/exception/InvalidAddressException.java
@@ -1,9 +1,8 @@
 package com.surrealdb.refactor.exception;
 
-import lombok.ToString;
-
 import java.net.URI;
 import java.util.Optional;
+import lombok.ToString;
 
 @ToString
 public class InvalidAddressException extends SurrealDBException {
@@ -11,7 +10,8 @@ public class InvalidAddressException extends SurrealDBException {
     private final URI address;
     private final InvalidAddressExceptionCause causeType;
 
-    public InvalidAddressException(URI address, InvalidAddressExceptionCause causeType, String message) {
+    public InvalidAddressException(
+            URI address, InvalidAddressExceptionCause causeType, String message) {
         super(message);
         this.address = address;
         this.causeType = causeType;
@@ -24,5 +24,4 @@ public class InvalidAddressException extends SurrealDBException {
     public InvalidAddressExceptionCause getCauseType() {
         return causeType;
     }
-
 }

--- a/src/main/java/com/surrealdb/refactor/exception/SurrealDBUnimplementedException.java
+++ b/src/main/java/com/surrealdb/refactor/exception/SurrealDBUnimplementedException.java
@@ -1,46 +1,24 @@
 package com.surrealdb.refactor.exception;
 
-import lombok.ToString;
-
 import java.net.MalformedURLException;
 import java.net.URL;
+import lombok.Getter;
+import lombok.ToString;
 
 @ToString
+@Getter
 public class SurrealDBUnimplementedException extends SurrealDBException {
 
     private final URL ticketLink;
     private final String message; // Necessary for lombok toString
 
-    public SurrealDBUnimplementedException(URL ticket, String message) {
+    public SurrealDBUnimplementedException(String ticket, String message) {
         super(message);
-        ticketLink = ticket;
-        this.message = message;
-    }
-
-    public URL getTicketLink() {
-        return ticketLink;
-    }
-
-    //----------------------------------------------------------------
-    // Builder
-
-    public static WithTicket withTicket(String url) {
         try {
-            URL ticket = new URL(url);
-            return new WithTicket(ticket);
+            ticketLink = new URL(ticket);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public static class WithTicket {
-        private final URL ticket;
-        WithTicket(URL ticket) {
-            this.ticket = ticket;
-        }
-
-        public SurrealDBUnimplementedException withMessage(String message) {
-            return new SurrealDBUnimplementedException(ticket, message);
-        }
+        this.message = message;
     }
 }

--- a/src/main/java/com/surrealdb/refactor/exception/SurrealDBUnimplementedException.java
+++ b/src/main/java/com/surrealdb/refactor/exception/SurrealDBUnimplementedException.java
@@ -1,14 +1,20 @@
 package com.surrealdb.refactor.exception;
 
+import lombok.ToString;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 
+@ToString
 public class SurrealDBUnimplementedException extends SurrealDBException {
 
     private final URL ticketLink;
+    private final String message; // Necessary for lombok toString
+
     public SurrealDBUnimplementedException(URL ticket, String message) {
         super(message);
         ticketLink = ticket;
+        this.message = message;
     }
 
     public URL getTicketLink() {

--- a/src/main/java/com/surrealdb/refactor/exception/UnhandledSurrealDBNettyState.java
+++ b/src/main/java/com/surrealdb/refactor/exception/UnhandledSurrealDBNettyState.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 public class UnhandledSurrealDBNettyState extends SurrealDBException {
     private final String reasonUnhandled;
     private final String causeOfError;
+
     public UnhandledSurrealDBNettyState(String reasonUnhandled, String causeOfError) {
         super(causeOfError);
         this.reasonUnhandled = reasonUnhandled;

--- a/src/main/java/com/surrealdb/refactor/exception/UnhandledSurrealDBNettyState.java
+++ b/src/main/java/com/surrealdb/refactor/exception/UnhandledSurrealDBNettyState.java
@@ -1,0 +1,16 @@
+package com.surrealdb.refactor.exception;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class UnhandledSurrealDBNettyState extends SurrealDBException {
+    private final String reasonUnhandled;
+    private final String causeOfError;
+    public UnhandledSurrealDBNettyState(String reasonUnhandled, String causeOfError) {
+        super(causeOfError);
+        this.reasonUnhandled = reasonUnhandled;
+        this.causeOfError = causeOfError;
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/exception/UnknownResponseToRequest.java
+++ b/src/main/java/com/surrealdb/refactor/exception/UnknownResponseToRequest.java
@@ -1,0 +1,16 @@
+package com.surrealdb.refactor.exception;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+public class UnknownResponseToRequest extends SurrealDBException {
+    @Getter private final String requestID;
+    @Getter private final String message;
+
+    public UnknownResponseToRequest(String requestID, String message) {
+        super(message);
+        this.requestID = requestID;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/types/Credentials.java
+++ b/src/main/java/com/surrealdb/refactor/types/Credentials.java
@@ -1,7 +1,15 @@
 package com.surrealdb.refactor.types;
 
-public class Credentials {
-    public Credentials(String username, String password) {
+import lombok.Getter;
 
+@Getter
+public class Credentials {
+
+    private final String username;
+    private final String password;
+
+    public Credentials(String username, String password) {
+        this.username = username;
+        this.password = password;
     }
 }

--- a/src/main/java/com/surrealdb/refactor/types/Value.java
+++ b/src/main/java/com/surrealdb/refactor/types/Value.java
@@ -11,6 +11,8 @@ public class Value implements IntoJson {
     }
 
     public static Value fromJson(JsonElement json) {
-        throw SurrealDBUnimplementedException.withTicket("https://github.com/surrealdb/surrealdb.java/issues/63").withMessage("Parsing general values from JSON is not implemented yet.");
+        throw new SurrealDBUnimplementedException(
+                "https://github.com/surrealdb/surrealdb.java/issues/63",
+                "Parsing general values from JSON is not implemented yet.");
     }
 }


### PR DESCRIPTION
Adds signin to websocket protocol rewrite.
Changes the netty implementation marginally as well.
Responses are now handled as futures (badly, because they are always object).

Resolves #62 