### PR TITLE
Query implementation with Params for WebSocket rewrite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,8 @@ tasks.register('integrationTest', Test) {
     environment('TEST_SURREAL_SCOPE', 'allusers')
 
     testLogging {
-        events "passed"
+        events "passed", "skipped", "failed", "standardOut", "standardError"
+        showStandardStreams = true
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ tasks.register('integrationTest', Test) {
     testLogging {
         events "passed", "skipped", "failed", "standardOut", "standardError"
         showStandardStreams = true
+        exceptionFormat = 'short'
     }
 }
 

--- a/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
+++ b/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
@@ -36,7 +36,7 @@ public class BaseIntegrationTest {
             testPort = container.get().getFirstMappedPort();
             // We need to wait for it to start 🥲
             try {
-                Thread.sleep(1000);
+                Thread.sleep(3000);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
+++ b/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
@@ -34,14 +34,13 @@ public class BaseIntegrationTest {
             container.get().start();
             testHost = container.get().getHost();
             testPort = container.get().getFirstMappedPort();
+            // We need to wait for it to start 🥲
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            System.err.println(
-            container.get().getLogs()
-            );
+            System.err.println(container.get().getLogs());
         }
     }
 

--- a/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
+++ b/src/intTest/java/com/surrealdb/BaseIntegrationTest.java
@@ -16,16 +16,6 @@ public class BaseIntegrationTest {
     protected static int testPort;
 
     @BeforeAll
-    public static void set_log_level() {
-        //        Logger srdbLog = LogManager.getLogManager();
-        //        srdbLog.setLevel(Level.ALL);
-        StreamHandler handler = new StreamHandler(System.out, new SimpleFormatter());
-        //        srdbLog.addHandler(handler);
-        Logger.getGlobal().setLevel(Level.ALL);
-        Logger.getGlobal().addHandler(handler);
-    }
-
-    @BeforeAll
     public static void create_connection() {
         // Check if both host and port have been decalred as environment variable overrides
         // if they have then use that address instead
@@ -44,6 +34,14 @@ public class BaseIntegrationTest {
             container.get().start();
             testHost = container.get().getHost();
             testPort = container.get().getFirstMappedPort();
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            System.err.println(
+            container.get().getLogs()
+            );
         }
     }
 

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -34,7 +34,7 @@ public class DemoScenarioTest extends BaseIntegrationTest {
 
         // Create a multi-statement query
         StringBuilder query =
-                new StringBuilder("INSERT person:lamport VALUES {'name': 'leslie'};\n");
+                new StringBuilder("INSERT person:lamport VALUES \\{'name': 'leslie'\\};\n");
         query.append("UPDATE $whichPerson SET year=$year;\n");
         query.append("DELETE person:lamport;");
 

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -9,6 +9,7 @@ import com.surrealdb.BaseIntegrationTest;
 import com.surrealdb.refactor.driver.*;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
+import com.surrealdb.refactor.types.QueryBlockResult;
 import com.surrealdb.refactor.types.surrealdb.Value;
 import java.net.URI;
 import java.util.List;
@@ -46,17 +47,17 @@ public class DemoScenarioTest extends BaseIntegrationTest {
                         new Param("year", Value.fromJson(new JsonPrimitive(2013))));
 
         // Execute the query
-        List<Value> results = surrealDB.query(query.toString(), params);
+        QueryBlockResult results = surrealDB.query(query.toString(), params);
 
         // Validate the results of the multi-statement query
-        assertEquals(results.size(), 3, results.toString());
+        assertEquals(results.getResult().size(), 3, results.toString());
         assertEquals(
-                results.get(0).intoJson(),
+                results.getResult().get(0).getResult().get(0).intoJson(),
                 asJson(
                         Tuple.of("name", new JsonPrimitive("leslie")),
                         Tuple.of("id", new JsonPrimitive("person:lamport"))));
         assertEquals(
-                results.get(1).intoJson(),
+                results.getResult().get(1).getResult().get(0).intoJson(),
                 asJson(
                         Tuple.of("name", new JsonPrimitive("leslie")),
                         Tuple.of("id", new JsonPrimitive("person:lamport"))));

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -1,5 +1,7 @@
 package com.surrealdb.refactor;
 
+import static com.surrealdb.refactor.Helpers.asMap;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.gson.JsonElement;
@@ -10,6 +12,8 @@ import com.surrealdb.refactor.driver.*;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
 import com.surrealdb.refactor.types.QueryBlockResult;
+import com.surrealdb.refactor.types.surrealdb.Number;
+import com.surrealdb.refactor.types.surrealdb.ObjectValue;
 import com.surrealdb.refactor.types.surrealdb.Value;
 import java.net.URI;
 import java.util.List;
@@ -49,18 +53,25 @@ public class DemoScenarioTest extends BaseIntegrationTest {
         // Execute the query
         QueryBlockResult results = surrealDB.query(query.toString(), params);
 
-        // Validate the results of the multi-statement query
+        // Validate the results of the first statement in the query
         assertEquals(results.getResult().size(), 3, results.toString());
-        assertEquals(
-                results.getResult().get(0).getResult().get(0).intoJson(),
-                asJson(
-                        Tuple.of("name", new JsonPrimitive("leslie")),
-                        Tuple.of("id", new JsonPrimitive("person:lamport"))));
-        assertEquals(
-                results.getResult().get(1).getResult().get(0).intoJson(),
-                asJson(
-                        Tuple.of("name", new JsonPrimitive("leslie")),
-                        Tuple.of("id", new JsonPrimitive("person:lamport"))));
+        Value expectedFirstValue = new Value(new ObjectValue(asMap(
+                Tuple.of("name", new Value("leslie")),
+                Tuple.of("id", new Value("person:lamport"))
+        )));
+        List<Value> actual = results.getResult().get(0).getResult();
+        assertArrayEquals(new Value[] {expectedFirstValue}, actual.toArray(new Value[0]));
+
+        // Validate the results of the second statement in the query
+        Value expectedSecondValue = new Value(new ObjectValue(
+                asMap(
+                        Tuple.of("name", new Value("leslie")),
+                        Tuple.of("id", new Value("person:lamport")),
+                        Tuple.of("year", new Value("2013.0"))
+                )
+        ));
+        List<Value> actualSecondValue = results.getResult().get(1).getResult();
+        assertArrayEquals(new Value[] {expectedSecondValue}, actualSecondValue.toArray(new Value[0]));
     }
 
     // ----------------------------------------------------------------

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -14,10 +14,12 @@ import com.surrealdb.refactor.types.surrealdb.ObjectValue;
 import com.surrealdb.refactor.types.surrealdb.Value;
 import java.net.URI;
 import java.util.List;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class DemoScenarioTest extends BaseIntegrationTest {
     @Test
+    @Disabled("Flaky on github CI")
     public void testDemoScenario() throws Exception {
         // Setup
         URI address =

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 public class DemoScenarioTest extends BaseIntegrationTest {
     @Test
-//    @Disabled("Functionality is unimplemented, but having the tests shows the design")
     public void testDemoScenario() throws Exception {
         // Setup
         URI address =
@@ -72,16 +71,10 @@ public class DemoScenarioTest extends BaseIntegrationTest {
         ));
         List<Value> actualSecondValue = results.getResult().get(1).getResult();
         assertArrayEquals(new Value[] {expectedSecondValue}, actualSecondValue.toArray(new Value[0]));
+
+        // Validate the results of the third statement in the query
+        List<Value> actualThirdValue = results.getResult().get(2).getResult();
+        assertArrayEquals(new Value[] {}, actualThirdValue.toArray(new Value[0]));
     }
 
-    // ----------------------------------------------------------------
-    // Helpers below this point
-
-    private static JsonObject asJson(Tuple<String, JsonElement>... data) {
-        JsonObject obj = new JsonObject();
-        for (Tuple<String, JsonElement> entry : data) {
-            obj.add(entry.key, entry.value);
-        }
-        return obj;
-    }
 }

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -4,20 +4,16 @@ import static com.surrealdb.refactor.Helpers.asMap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.surrealdb.BaseIntegrationTest;
 import com.surrealdb.refactor.driver.*;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
 import com.surrealdb.refactor.types.QueryBlockResult;
-import com.surrealdb.refactor.types.surrealdb.Number;
 import com.surrealdb.refactor.types.surrealdb.ObjectValue;
 import com.surrealdb.refactor.types.surrealdb.Value;
 import java.net.URI;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class DemoScenarioTest extends BaseIntegrationTest {
@@ -54,27 +50,29 @@ public class DemoScenarioTest extends BaseIntegrationTest {
 
         // Validate the results of the first statement in the query
         assertEquals(results.getResult().size(), 3, results.toString());
-        Value expectedFirstValue = new Value(new ObjectValue(asMap(
-                Tuple.of("name", new Value("leslie")),
-                Tuple.of("id", new Value("person:lamport"))
-        )));
+        Value expectedFirstValue =
+                new Value(
+                        new ObjectValue(
+                                asMap(
+                                        Tuple.of("name", new Value("leslie")),
+                                        Tuple.of("id", new Value("person:lamport")))));
         List<Value> actual = results.getResult().get(0).getResult();
         assertArrayEquals(new Value[] {expectedFirstValue}, actual.toArray(new Value[0]));
 
         // Validate the results of the second statement in the query
-        Value expectedSecondValue = new Value(new ObjectValue(
-                asMap(
-                        Tuple.of("name", new Value("leslie")),
-                        Tuple.of("id", new Value("person:lamport")),
-                        Tuple.of("year", new Value("2013.0"))
-                )
-        ));
+        Value expectedSecondValue =
+                new Value(
+                        new ObjectValue(
+                                asMap(
+                                        Tuple.of("name", new Value("leslie")),
+                                        Tuple.of("id", new Value("person:lamport")),
+                                        Tuple.of("year", new Value("2013.0")))));
         List<Value> actualSecondValue = results.getResult().get(1).getResult();
-        assertArrayEquals(new Value[] {expectedSecondValue}, actualSecondValue.toArray(new Value[0]));
+        assertArrayEquals(
+                new Value[] {expectedSecondValue}, actualSecondValue.toArray(new Value[0]));
 
         // Validate the results of the third statement in the query
         List<Value> actualThirdValue = results.getResult().get(2).getResult();
         assertArrayEquals(new Value[] {}, actualThirdValue.toArray(new Value[0]));
     }
-
 }

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 public class DemoScenarioTest extends BaseIntegrationTest {
     @Test
-    @Disabled("Functionality is unimplemented, but having the tests shows the design")
+//    @Disabled("Functionality is unimplemented, but having the tests shows the design")
     public void testDemoScenario() throws Exception {
         // Setup
         URI address =
@@ -49,7 +49,7 @@ public class DemoScenarioTest extends BaseIntegrationTest {
         List<Value> results = surrealDB.query(query.toString(), params);
 
         // Validate the results of the multi-statement query
-        assertEquals(results.size(), 3);
+        assertEquals(results.size(), 3, results.toString());
         assertEquals(
                 results.get(0).intoJson(),
                 asJson(

--- a/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
+++ b/src/intTest/java/com/surrealdb/refactor/DemoScenarioTest.java
@@ -34,7 +34,7 @@ public class DemoScenarioTest extends BaseIntegrationTest {
 
         // Create a multi-statement query
         StringBuilder query =
-                new StringBuilder("INSERT person:lamport VALUES \\{'name': 'leslie'\\};\n");
+                new StringBuilder("CREATE person:lamport CONTENT {name: 'leslie'};\n");
         query.append("UPDATE $whichPerson SET year=$year;\n");
         query.append("DELETE person:lamport;");
 

--- a/src/intTest/java/com/surrealdb/refactor/Helpers.java
+++ b/src/intTest/java/com/surrealdb/refactor/Helpers.java
@@ -1,7 +1,6 @@
 package com.surrealdb.refactor;
 
 import com.surrealdb.refactor.types.surrealdb.Value;
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/intTest/java/com/surrealdb/refactor/Helpers.java
+++ b/src/intTest/java/com/surrealdb/refactor/Helpers.java
@@ -1,0 +1,16 @@
+package com.surrealdb.refactor;
+
+import com.surrealdb.refactor.types.surrealdb.Value;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Helpers {
+    public static Map<String, Value> asMap(Tuple<String, Value>... data) {
+        Map<String, Value> obj = new HashMap<>();
+        for (Tuple<String, Value> entry : data) {
+            obj.put(entry.key, entry.value);
+        }
+        return obj;
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/driver/HttpConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/HttpConnection.java
@@ -5,6 +5,7 @@ import com.surrealdb.refactor.exception.InvalidAddressExceptionCause;
 import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
+import com.surrealdb.refactor.types.QueryBlockResult;
 import com.surrealdb.refactor.types.surrealdb.Value;
 import java.net.URI;
 import java.util.Arrays;
@@ -26,7 +27,7 @@ public class HttpConnection {
                 StatelessSurrealDB surrealdb =
                         new StatelessSurrealDB() {
                             @Override
-                            public List<Value> query(String query, List<Param> params) {
+                            public QueryBlockResult query(String query, List<Param> params) {
                                 throw new SurrealDBUnimplementedException(
                                         "https://github.com/surrealdb/surrealdb.java/issues/61",
                                         "HTTP connections are not yet implemented");

--- a/src/main/java/com/surrealdb/refactor/driver/HttpConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/HttpConnection.java
@@ -6,7 +6,6 @@ import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
 import com.surrealdb.refactor.types.QueryBlockResult;
-import com.surrealdb.refactor.types.surrealdb.Value;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/com/surrealdb/refactor/driver/QueryMessage.java
+++ b/src/main/java/com/surrealdb/refactor/driver/QueryMessage.java
@@ -1,6 +1,8 @@
 package com.surrealdb.refactor.driver;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.surrealdb.refactor.types.Param;
 import lombok.Getter;
@@ -16,17 +18,20 @@ public class QueryMessage {
     private final String method = "query";
     private final String id;
 
-    private final String[] params;
+    private final JsonArray params;
 
     public QueryMessage(String requestID, String query, List<Param> params) {
         id = requestID;
-        List<String> list = new ArrayList<>();
-        list.add(query);
+        JsonArray requestParamList = new JsonArray();
+        // First item in list is string of the query
+        requestParamList.add(query);
+        // Second item in the list is an object of bindings
+        JsonObject bindings = new JsonObject();
         for (Param param: params) {
-            JsonObject paramEntry = new JsonObject();
-            paramEntry.add(param.getIdentifier(), param.getValue().intoJson());
-            list.add(paramEntry.toString());
+            System.out.printf("Handling Param %s with id = '%s' and value = '%s'\n", param, param.getIdentifier(), param.getValue().intoJson());
+            bindings.add(param.getIdentifier(), param.getValue().intoJson());
         }
-        this.params = list.toArray(new String[0]);
+        requestParamList.add(bindings);
+        this.params = requestParamList;
     }
 }

--- a/src/main/java/com/surrealdb/refactor/driver/QueryMessage.java
+++ b/src/main/java/com/surrealdb/refactor/driver/QueryMessage.java
@@ -1,16 +1,11 @@
 package com.surrealdb.refactor.driver;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.surrealdb.refactor.types.Param;
+import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 @Getter
 @ToString
@@ -27,8 +22,10 @@ public class QueryMessage {
         requestParamList.add(query);
         // Second item in the list is an object of bindings
         JsonObject bindings = new JsonObject();
-        for (Param param: params) {
-            System.out.printf("Handling Param %s with id = '%s' and value = '%s'\n", param, param.getIdentifier(), param.getValue().intoJson());
+        for (Param param : params) {
+            System.out.printf(
+                    "Handling Param %s with id = '%s' and value = '%s'\n",
+                    param, param.getIdentifier(), param.getValue().intoJson());
             bindings.add(param.getIdentifier(), param.getValue().intoJson());
         }
         requestParamList.add(bindings);

--- a/src/main/java/com/surrealdb/refactor/driver/QueryMessage.java
+++ b/src/main/java/com/surrealdb/refactor/driver/QueryMessage.java
@@ -1,0 +1,32 @@
+package com.surrealdb.refactor.driver;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.surrealdb.refactor.types.Param;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@ToString
+public class QueryMessage {
+    private final String method = "query";
+    private final String id;
+
+    private final String[] params;
+
+    public QueryMessage(String requestID, String query, List<Param> params) {
+        id = requestID;
+        List<String> list = new ArrayList<>();
+        list.add(query);
+        for (Param param: params) {
+            JsonObject paramEntry = new JsonObject();
+            paramEntry.add(param.getIdentifier(), param.getValue().intoJson());
+            list.add(paramEntry.toString());
+        }
+        this.params = list.toArray(new String[0]);
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/driver/StatelessSurrealDB.java
+++ b/src/main/java/com/surrealdb/refactor/driver/StatelessSurrealDB.java
@@ -1,6 +1,7 @@
 package com.surrealdb.refactor.driver;
 
 import com.surrealdb.refactor.types.Param;
+import com.surrealdb.refactor.types.QueryBlockResult;
 import com.surrealdb.refactor.types.surrealdb.Value;
 import java.util.List;
 
@@ -12,5 +13,5 @@ public interface StatelessSurrealDB {
      * @param query
      * @return
      */
-    List<Value> query(String query, List<Param> params);
+    QueryBlockResult query(String query, List<Param> params);
 }

--- a/src/main/java/com/surrealdb/refactor/driver/StatelessSurrealDB.java
+++ b/src/main/java/com/surrealdb/refactor/driver/StatelessSurrealDB.java
@@ -2,7 +2,6 @@ package com.surrealdb.refactor.driver;
 
 import com.surrealdb.refactor.types.Param;
 import com.surrealdb.refactor.types.QueryBlockResult;
-import com.surrealdb.refactor.types.surrealdb.Value;
 import java.util.List;
 
 /** StatelessSurrealDB is the baseline interface available for all SurrealDB instances. */

--- a/src/main/java/com/surrealdb/refactor/driver/SurrealDBFactory.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SurrealDBFactory.java
@@ -4,6 +4,7 @@ import com.surrealdb.refactor.exception.InvalidAddressException;
 import com.surrealdb.refactor.exception.InvalidAddressExceptionCause;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -54,6 +55,13 @@ public class SurrealDBFactory {
         String key = uri.getScheme().toLowerCase().trim();
         if (!bidirectionalDrivers.containsKey(key)) {
             throw new InvalidAddressException(uri, InvalidAddressExceptionCause.INVALID_SCHEME,"Schema is unsupported for bidirectional service");
+        }
+        if (uri.getPath() == "") {
+            try {
+                uri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), uri.getPath()+"/rpc", uri.getQuery(), uri.getFragment());
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
         }
         return bidirectionalDrivers.get(key).apply(uri);
     }

--- a/src/main/java/com/surrealdb/refactor/driver/SurrealDBFactory.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SurrealDBFactory.java
@@ -59,7 +59,7 @@ public class SurrealDBFactory {
                     InvalidAddressExceptionCause.INVALID_SCHEME,
                     "Schema is unsupported for bidirectional service");
         }
-        if (uri.getPath() == "") {
+        if (uri.getPath().isEmpty()) {
             try {
                 uri =
                         new URI(

--- a/src/main/java/com/surrealdb/refactor/driver/SurrealDBFactory.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SurrealDBFactory.java
@@ -2,22 +2,20 @@ package com.surrealdb.refactor.driver;
 
 import com.surrealdb.refactor.exception.InvalidAddressException;
 import com.surrealdb.refactor.exception.InvalidAddressExceptionCause;
-
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-/**
- * SurrealDBFactory is the go-to class for creating new SurrealDB driver instances.
- */
+/** SurrealDBFactory is the go-to class for creating new SurrealDB driver instances. */
 public class SurrealDBFactory {
 
-    interface StatelessProvider extends Function<URI, UnauthenticatedSurrealDB<StatelessSurrealDB>> {}
-    interface BidirectionalProvider extends Function<URI, UnauthenticatedSurrealDB<BidirectionalSurrealDB>> {}
+    interface StatelessProvider
+            extends Function<URI, UnauthenticatedSurrealDB<StatelessSurrealDB>> {}
+
+    interface BidirectionalProvider
+            extends Function<URI, UnauthenticatedSurrealDB<BidirectionalSurrealDB>> {}
 
     private final Map<String, StatelessProvider> statelessDrivers;
     private final Map<String, BidirectionalProvider> bidirectionalDrivers;
@@ -26,7 +24,9 @@ public class SurrealDBFactory {
         this(getDefaultStatelessDrivers(), getDefaultBidirectionalDrivers());
     }
 
-    public SurrealDBFactory(Map<String, StatelessProvider> statelessDrivers, Map<String, BidirectionalProvider> bidirectionalDrivers) {
+    public SurrealDBFactory(
+            Map<String, StatelessProvider> statelessDrivers,
+            Map<String, BidirectionalProvider> bidirectionalDrivers) {
         this.statelessDrivers = statelessDrivers;
         this.bidirectionalDrivers = bidirectionalDrivers;
     }
@@ -54,16 +54,26 @@ public class SurrealDBFactory {
     public UnauthenticatedSurrealDB<BidirectionalSurrealDB> connectBidirectional(URI uri) {
         String key = uri.getScheme().toLowerCase().trim();
         if (!bidirectionalDrivers.containsKey(key)) {
-            throw new InvalidAddressException(uri, InvalidAddressExceptionCause.INVALID_SCHEME,"Schema is unsupported for bidirectional service");
+            throw new InvalidAddressException(
+                    uri,
+                    InvalidAddressExceptionCause.INVALID_SCHEME,
+                    "Schema is unsupported for bidirectional service");
         }
         if (uri.getPath() == "") {
             try {
-                uri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), uri.getPath()+"/rpc", uri.getQuery(), uri.getFragment());
+                uri =
+                        new URI(
+                                uri.getScheme(),
+                                uri.getUserInfo(),
+                                uri.getHost(),
+                                uri.getPort(),
+                                uri.getPath() + "/rpc",
+                                uri.getQuery(),
+                                uri.getFragment());
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             }
         }
         return bidirectionalDrivers.get(key).apply(uri);
     }
-
 }

--- a/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientProtocolHandler.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientProtocolHandler.java
@@ -90,7 +90,9 @@ public class SurrealDBWebsocketClientProtocolHandler
         String method = "query";
         checkChannelAndThrow(method);
         QueryMessage queryMessage = new QueryMessage(requestID, query, params);
-        return sendAndPromise(method, requestID, new Gson().toJson(queryMessage));
+        String serialised = new Gson().toJson(queryMessage);
+        System.out.printf("Sending query: %s\n", serialised);
+        return sendAndPromise(method, requestID, serialised);
     }
 
     public Future<Object> signin(Credentials credentials) {

--- a/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientProtocolHandler.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientProtocolHandler.java
@@ -9,13 +9,10 @@ import com.surrealdb.refactor.exception.UnhandledSurrealDBNettyState;
 import com.surrealdb.refactor.exception.UnknownResponseToRequest;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
-import com.surrealdb.refactor.types.QueryBlockResult;
 import io.netty.channel.*;
 import io.netty.handler.codec.http.websocketx.*;
 import io.netty.util.concurrent.Promise;
-
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -159,5 +156,4 @@ public class SurrealDBWebsocketClientProtocolHandler
                             requestID));
         }
     }
-
 }

--- a/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientProtocolHandler.java
+++ b/src/main/java/com/surrealdb/refactor/driver/SurrealDBWebsocketClientProtocolHandler.java
@@ -8,9 +8,13 @@ import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.exception.UnhandledSurrealDBNettyState;
 import com.surrealdb.refactor.exception.UnknownResponseToRequest;
 import com.surrealdb.refactor.types.Credentials;
+import com.surrealdb.refactor.types.Param;
 import io.netty.channel.*;
 import io.netty.handler.codec.http.websocketx.*;
 import io.netty.util.concurrent.Promise;
+
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -82,6 +86,13 @@ public class SurrealDBWebsocketClientProtocolHandler
         ctx.close();
     }
 
+    public Future<Object> query(String requestID, String query, List<Param> params) {
+        String method = "query";
+        checkChannelAndThrow(method);
+        QueryMessage queryMessage = new QueryMessage(requestID, query, params);
+        return sendAndPromise(method, requestID, new Gson().toJson(queryMessage));
+    }
+
     public Future<Object> signin(Credentials credentials) {
         return signin(UUID.randomUUID().toString(), credentials);
     }
@@ -96,11 +107,11 @@ public class SurrealDBWebsocketClientProtocolHandler
         return sendAndPromise(method, requestID, new Gson().toJson(signinMessage));
     }
 
-    public Promise<Object> use(String namespace, String database) {
+    public Future<Object> use(String namespace, String database) {
         return use(UUID.randomUUID().toString(), namespace, database);
     }
 
-    public Promise<Object> use(String requestID, String namespace, String database) {
+    public Future<Object> use(String requestID, String namespace, String database) {
         String method = "use";
         checkChannelAndThrow(method);
         UseMessage useMessage = new UseMessage(requestID, namespace, database);
@@ -145,4 +156,5 @@ public class SurrealDBWebsocketClientProtocolHandler
                             requestID));
         }
     }
+
 }

--- a/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
@@ -30,16 +30,12 @@ public class WsPlaintextConnection {
     private static final EventLoopGroup group = new NioEventLoopGroup();
     private static final int MAX_CONTENT_LENGTH = 65536;
 
-    private final Gson gson;
-
-    public WsPlaintextConnection() {
-        gson = new GsonBuilder().disableHtmlEscaping().create();
-    }
+    public WsPlaintextConnection() {}
 
     public static UnauthenticatedSurrealDB<BidirectionalSurrealDB> connect(URI uri) {
         Channel channel;
+        System.out.printf("Connecting to %s\n", uri);
         try {
-            System.out.printf("Connecting to %s\n", uri);
             channel = bootstrapProtocol(uri).connect(uri.getHost(), uri.getPort()).sync().channel();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
@@ -1,5 +1,7 @@
 package com.surrealdb.refactor.driver;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
@@ -28,6 +30,14 @@ public class WsPlaintextConnection {
     private static final EventLoopGroup group = new NioEventLoopGroup();
     private static final int MAX_CONTENT_LENGTH = 65536;
 
+    private final Gson gson;
+
+    public WsPlaintextConnection() {
+        gson = new GsonBuilder()
+                .disableHtmlEscaping()
+                .create();
+    }
+
     public static UnauthenticatedSurrealDB<BidirectionalSurrealDB> connect(URI uri) {
         Channel channel;
         try {
@@ -49,7 +59,7 @@ public class WsPlaintextConnection {
                 } catch (InterruptedException | ExecutionException | TimeoutException e) {
                     throw new RuntimeException(e);
                 }
-                System.out.printf("Successfully signed in: %s", result);
+                System.out.printf("Successfully signed in: %s\n", result);
                 BidirectionalSurrealDB surrealdb =
                         new BidirectionalSurrealDB() {
 

--- a/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
@@ -14,7 +14,9 @@ import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -53,9 +55,14 @@ public class WsPlaintextConnection {
 
                             @Override
                             public List<Value> query(String query, List<Param> params) {
-                                throw new SurrealDBUnimplementedException(
-                                        "https://github.com/surrealdb/surrealdb.java/issues/62",
-                                        "Plaintext websocket connections are not supported yet");
+                                Object resp = null;
+                                try {
+                                    resp = srdbHandler.query(UUID.randomUUID().toString(), query, params).get(2, TimeUnit.SECONDS);
+                                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                                    throw new RuntimeException(e);
+                                }
+                                List<Value> casted = Arrays.asList(new Value(resp.toString()));
+                                return casted;
                             }
                         };
                 return new UnusedSurrealDB<>() {

--- a/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
@@ -2,9 +2,12 @@ package com.surrealdb.refactor.driver;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
+import com.surrealdb.refactor.types.QueryBlockResult;
+import com.surrealdb.refactor.types.QueryResult;
 import com.surrealdb.refactor.types.surrealdb.Value;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
@@ -64,15 +67,15 @@ public class WsPlaintextConnection {
                         new BidirectionalSurrealDB() {
 
                             @Override
-                            public List<Value> query(String query, List<Param> params) {
-                                Object resp = null;
+                            public QueryBlockResult query(String query, List<Param> params) {
+                                JsonObject resp = null;
                                 try {
                                     resp = srdbHandler.query(UUID.randomUUID().toString(), query, params).get(2, TimeUnit.SECONDS);
                                 } catch (InterruptedException | ExecutionException | TimeoutException e) {
                                     throw new RuntimeException(e);
                                 }
                                 List<Value> casted = Arrays.asList(new Value(resp.toString()));
-                                return casted;
+                                return new QueryBlockResult(List.of(new QueryResult(casted, "change this status", "change this time")));
                             }
                         };
                 return new UnusedSurrealDB<>() {

--- a/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
@@ -2,7 +2,9 @@ package com.surrealdb.refactor.driver;
 
 import com.google.gson.*;
 import com.surrealdb.refactor.driver.parsing.JsonQueryResultParser;
+import com.surrealdb.refactor.exception.SurrealDBException;
 import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
+import com.surrealdb.refactor.exception.UnhandledProtocolResponse;
 import com.surrealdb.refactor.types.Credentials;
 import com.surrealdb.refactor.types.Param;
 import com.surrealdb.refactor.types.QueryBlockResult;
@@ -72,7 +74,7 @@ public class WsPlaintextConnection {
                                 }
                                 // Process the query list
                                 if (!resp.has("result")) {
-                                    throw new SurrealDBUnimplementedException("todo create ticket", "The response for the query did not contain a result field");
+                                    throw new UnhandledProtocolResponse("Expected the response to contain a result");
                                 }
                                 JsonElement outerResultJson = resp.get("result");
                                 QueryResult[] processedOuterResults;
@@ -81,14 +83,14 @@ public class WsPlaintextConnection {
                                     processedOuterResults = new QueryResult[outerResultArray.size()];
                                     for (int i=0; i<outerResultArray.size(); i++ ) {
                                         JsonElement innerResultJson = outerResultArray.get(i);
-                                        if (innerResultJson.isJsonArray()) {
-                                            throw new SurrealDBUnimplementedException("https://todo.com", "The individual result in an array of query results was not an array");
+                                        if (!innerResultJson.isJsonObject()) {
+                                            throw new UnhandledProtocolResponse("Expected the result to be an object");
                                         }
                                         QueryResult val = new JsonQueryResultParser().parse(innerResultJson);
                                         processedOuterResults[i] = val;
                                     }
                                 } else {
-                                    throw new SurrealDBUnimplementedException("todo create ticket", "The response contained results that were not in an array");
+                                    throw new SurrealDBUnimplementedException("https://github.com/surrealdb/surrealdb.java/issues/75", "The response contained results that were not in an array");
                                 }
                                 return new QueryBlockResult(Arrays.asList(processedOuterResults));
                             }

--- a/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
@@ -2,7 +2,6 @@ package com.surrealdb.refactor.driver;
 
 import com.google.gson.*;
 import com.surrealdb.refactor.driver.parsing.JsonQueryResultParser;
-import com.surrealdb.refactor.exception.SurrealDBException;
 import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.exception.UnhandledProtocolResponse;
 import com.surrealdb.refactor.types.Credentials;
@@ -34,9 +33,7 @@ public class WsPlaintextConnection {
     private final Gson gson;
 
     public WsPlaintextConnection() {
-        gson = new GsonBuilder()
-                .disableHtmlEscaping()
-                .create();
+        gson = new GsonBuilder().disableHtmlEscaping().create();
     }
 
     public static UnauthenticatedSurrealDB<BidirectionalSurrealDB> connect(URI uri) {
@@ -68,29 +65,43 @@ public class WsPlaintextConnection {
                             public QueryBlockResult query(String query, List<Param> params) {
                                 JsonObject resp = null;
                                 try {
-                                    resp = srdbHandler.query(UUID.randomUUID().toString(), query, params).get(2, TimeUnit.SECONDS);
-                                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                                    resp =
+                                            srdbHandler
+                                                    .query(
+                                                            UUID.randomUUID().toString(),
+                                                            query,
+                                                            params)
+                                                    .get(2, TimeUnit.SECONDS);
+                                } catch (InterruptedException
+                                        | ExecutionException
+                                        | TimeoutException e) {
                                     throw new RuntimeException(e);
                                 }
                                 // Process the query list
                                 if (!resp.has("result")) {
-                                    throw new UnhandledProtocolResponse("Expected the response to contain a result");
+                                    throw new UnhandledProtocolResponse(
+                                            "Expected the response to contain a result");
                                 }
                                 JsonElement outerResultJson = resp.get("result");
                                 QueryResult[] processedOuterResults;
                                 if (outerResultJson.isJsonArray()) {
                                     JsonArray outerResultArray = outerResultJson.getAsJsonArray();
-                                    processedOuterResults = new QueryResult[outerResultArray.size()];
-                                    for (int i=0; i<outerResultArray.size(); i++ ) {
+                                    processedOuterResults =
+                                            new QueryResult[outerResultArray.size()];
+                                    for (int i = 0; i < outerResultArray.size(); i++) {
                                         JsonElement innerResultJson = outerResultArray.get(i);
                                         if (!innerResultJson.isJsonObject()) {
-                                            throw new UnhandledProtocolResponse("Expected the result to be an object");
+                                            throw new UnhandledProtocolResponse(
+                                                    "Expected the result to be an object");
                                         }
-                                        QueryResult val = new JsonQueryResultParser().parse(innerResultJson);
+                                        QueryResult val =
+                                                new JsonQueryResultParser().parse(innerResultJson);
                                         processedOuterResults[i] = val;
                                     }
                                 } else {
-                                    throw new SurrealDBUnimplementedException("https://github.com/surrealdb/surrealdb.java/issues/75", "The response contained results that were not in an array");
+                                    throw new SurrealDBUnimplementedException(
+                                            "https://github.com/surrealdb/surrealdb.java/issues/75",
+                                            "The response contained results that were not in an array");
                                 }
                                 return new QueryBlockResult(Arrays.asList(processedOuterResults));
                             }

--- a/src/main/java/com/surrealdb/refactor/driver/parsing/JsonQueryResultParser.java
+++ b/src/main/java/com/surrealdb/refactor/driver/parsing/JsonQueryResultParser.java
@@ -3,6 +3,7 @@ package com.surrealdb.refactor.driver.parsing;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.surrealdb.refactor.exception.SurrealDBException;
 import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.exception.UnhandledProtocolResponse;
 import com.surrealdb.refactor.types.QueryResult;
@@ -74,6 +75,6 @@ public class JsonQueryResultParser {
         } else if (jsonElement.isJsonPrimitive()) {
             return PRIMTIVE;
         }
-        throw new SurrealDBUnimplementedException("todo create ticket", "really we should be doing more in depth handling of types to also give Value types");
+        throw new SurrealDBException("There is an unknown JsonElement type");
     }
 }

--- a/src/main/java/com/surrealdb/refactor/driver/parsing/JsonQueryResultParser.java
+++ b/src/main/java/com/surrealdb/refactor/driver/parsing/JsonQueryResultParser.java
@@ -1,0 +1,79 @@
+package com.surrealdb.refactor.driver.parsing;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
+import com.surrealdb.refactor.exception.UnhandledProtocolResponse;
+import com.surrealdb.refactor.types.QueryResult;
+import com.surrealdb.refactor.types.surrealdb.ObjectValue;
+import com.surrealdb.refactor.types.surrealdb.Value;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JsonQueryResultParser {
+    private static final String ARRAY = "Array";
+    private static final String OBJECT = "Object";
+    private static final String PRIMTIVE = "Primitive";
+    private static final String NULL = "Null";
+
+    public QueryResult parse(JsonElement jsonElement) {
+        // Test
+        if (!jsonElement.isJsonObject()) {
+            throw new UnhandledProtocolResponse(String.format("Expected json object, but was %s", type(jsonElement)));
+        }
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+        String status = forceGet(jsonObject, "status", new UnhandledProtocolResponse("Expected the object to have a status")).getAsString();
+        String time = forceGet(jsonObject, "time", new UnhandledProtocolResponse("Expected the object to have a time")).getAsString();
+        JsonElement result = forceGet(jsonObject, "result", new UnhandledProtocolResponse("Expected the object to contain a result"));
+        List<Value> valueList = new ArrayList<>();
+        if (result.isJsonObject()) {
+            JsonObject object = result.getAsJsonObject();
+            valueList.add(parseValue(object));
+        } else if (result.isJsonArray()) {
+            JsonArray array = result.getAsJsonArray();
+            for (JsonElement arrayElement: array) {
+                valueList.add(parseValue(arrayElement));
+            }
+        } else {
+            throw new UnhandledProtocolResponse(String.format("Expected the result type in a result to be an object of array instead was: %s", type(jsonElement)));
+        }
+        return new QueryResult(valueList, status, time);
+    }
+
+    private Value parseValue(JsonElement jsonElement) {
+        if (!jsonElement.isJsonObject()) {
+            throw new UnhandledProtocolResponse(String.format("Expected the result type to be object but was %s", type(jsonElement)));
+        }
+        Map<String, Value> objectProperties = new HashMap<>();
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+        for (Map.Entry<String, JsonElement> entry: jsonObject.entrySet()) {
+            String value = entry.getValue().getAsString();
+            objectProperties.put(entry.getKey(), new Value(value));
+        }
+        return new Value(new ObjectValue(objectProperties));
+    }
+
+    private JsonElement forceGet(JsonObject jsonObject, String property, UnhandledProtocolResponse cause) {
+        if (!jsonObject.has(property)) {
+            throw cause;
+        }
+        return jsonObject.get(property);
+    }
+
+    private static String type(JsonElement jsonElement) {
+        if (jsonElement.isJsonArray()) {
+            return ARRAY;
+        } else if (jsonElement.isJsonObject()) {
+            return OBJECT;
+        } else if (jsonElement.isJsonNull()) {
+            return NULL;
+        } else if (jsonElement.isJsonPrimitive()) {
+            return PRIMTIVE;
+        }
+        throw new SurrealDBUnimplementedException("todo create ticket", "really we should be doing more in depth handling of types to also give Value types");
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/driver/parsing/JsonQueryResultParser.java
+++ b/src/main/java/com/surrealdb/refactor/driver/parsing/JsonQueryResultParser.java
@@ -4,12 +4,10 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.surrealdb.refactor.exception.SurrealDBException;
-import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.exception.UnhandledProtocolResponse;
 import com.surrealdb.refactor.types.QueryResult;
 import com.surrealdb.refactor.types.surrealdb.ObjectValue;
 import com.surrealdb.refactor.types.surrealdb.Value;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -24,41 +22,63 @@ public class JsonQueryResultParser {
     public QueryResult parse(JsonElement jsonElement) {
         // Test
         if (!jsonElement.isJsonObject()) {
-            throw new UnhandledProtocolResponse(String.format("Expected json object, but was %s", type(jsonElement)));
+            throw new UnhandledProtocolResponse(
+                    String.format("Expected json object, but was %s", type(jsonElement)));
         }
         JsonObject jsonObject = jsonElement.getAsJsonObject();
-        String status = forceGet(jsonObject, "status", new UnhandledProtocolResponse("Expected the object to have a status")).getAsString();
-        String time = forceGet(jsonObject, "time", new UnhandledProtocolResponse("Expected the object to have a time")).getAsString();
-        JsonElement result = forceGet(jsonObject, "result", new UnhandledProtocolResponse("Expected the object to contain a result"));
+        String status =
+                forceGet(
+                                jsonObject,
+                                "status",
+                                new UnhandledProtocolResponse(
+                                        "Expected the object to have a status"))
+                        .getAsString();
+        String time =
+                forceGet(
+                                jsonObject,
+                                "time",
+                                new UnhandledProtocolResponse("Expected the object to have a time"))
+                        .getAsString();
+        JsonElement result =
+                forceGet(
+                        jsonObject,
+                        "result",
+                        new UnhandledProtocolResponse("Expected the object to contain a result"));
         List<Value> valueList = new ArrayList<>();
         if (result.isJsonObject()) {
             JsonObject object = result.getAsJsonObject();
             valueList.add(parseValue(object));
         } else if (result.isJsonArray()) {
             JsonArray array = result.getAsJsonArray();
-            for (JsonElement arrayElement: array) {
+            for (JsonElement arrayElement : array) {
                 valueList.add(parseValue(arrayElement));
             }
         } else {
-            throw new UnhandledProtocolResponse(String.format("Expected the result type in a result to be an object of array instead was: %s", type(jsonElement)));
+            throw new UnhandledProtocolResponse(
+                    String.format(
+                            "Expected the result type in a result to be an object of array instead was: %s",
+                            type(jsonElement)));
         }
         return new QueryResult(valueList, status, time);
     }
 
     private Value parseValue(JsonElement jsonElement) {
         if (!jsonElement.isJsonObject()) {
-            throw new UnhandledProtocolResponse(String.format("Expected the result type to be object but was %s", type(jsonElement)));
+            throw new UnhandledProtocolResponse(
+                    String.format(
+                            "Expected the result type to be object but was %s", type(jsonElement)));
         }
         Map<String, Value> objectProperties = new HashMap<>();
         JsonObject jsonObject = jsonElement.getAsJsonObject();
-        for (Map.Entry<String, JsonElement> entry: jsonObject.entrySet()) {
+        for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
             String value = entry.getValue().getAsString();
             objectProperties.put(entry.getKey(), new Value(value));
         }
         return new Value(new ObjectValue(objectProperties));
     }
 
-    private JsonElement forceGet(JsonObject jsonObject, String property, UnhandledProtocolResponse cause) {
+    private JsonElement forceGet(
+            JsonObject jsonObject, String property, UnhandledProtocolResponse cause) {
         if (!jsonObject.has(property)) {
             throw cause;
         }

--- a/src/main/java/com/surrealdb/refactor/exception/UnhandledProtocolResponse.java
+++ b/src/main/java/com/surrealdb/refactor/exception/UnhandledProtocolResponse.java
@@ -1,0 +1,14 @@
+package com.surrealdb.refactor.exception;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class UnhandledProtocolResponse extends SurrealDBException{
+    private final String message;
+    public UnhandledProtocolResponse(String message) {
+        super(message);
+        this.message = message;
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/exception/UnhandledProtocolResponse.java
+++ b/src/main/java/com/surrealdb/refactor/exception/UnhandledProtocolResponse.java
@@ -5,8 +5,9 @@ import lombok.ToString;
 
 @Getter
 @ToString
-public class UnhandledProtocolResponse extends SurrealDBException{
+public class UnhandledProtocolResponse extends SurrealDBException {
     private final String message;
+
     public UnhandledProtocolResponse(String message) {
         super(message);
         this.message = message;

--- a/src/main/java/com/surrealdb/refactor/types/Param.java
+++ b/src/main/java/com/surrealdb/refactor/types/Param.java
@@ -1,7 +1,11 @@
 package com.surrealdb.refactor.types;
 
 import com.surrealdb.refactor.types.surrealdb.Value;
+import lombok.Getter;
+import lombok.ToString;
 
+@Getter
+@ToString
 public class Param {
     private final String identifier;
     private final Value value;

--- a/src/main/java/com/surrealdb/refactor/types/QueryBlockResult.java
+++ b/src/main/java/com/surrealdb/refactor/types/QueryBlockResult.java
@@ -1,9 +1,7 @@
 package com.surrealdb.refactor.types;
 
-import lombok.Getter;
-import lombok.ToString;
-
 import java.util.List;
+import lombok.ToString;
 
 @ToString
 public class QueryBlockResult {
@@ -15,6 +13,7 @@ public class QueryBlockResult {
 
     /**
      * Get all the query results from the query
+     *
      * @return the result of each individual statement in a query block
      */
     public List<QueryResult> getResult() {

--- a/src/main/java/com/surrealdb/refactor/types/QueryBlockResult.java
+++ b/src/main/java/com/surrealdb/refactor/types/QueryBlockResult.java
@@ -1,0 +1,23 @@
+package com.surrealdb.refactor.types;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@ToString
+public class QueryBlockResult {
+    private final List<QueryResult> result;
+
+    public QueryBlockResult(List<QueryResult> result) {
+        this.result = result;
+    }
+
+    /**
+     * Get all the query results from the query
+     * @return the result of each individual statement in a query block
+     */
+    public List<QueryResult> getResult() {
+        return result;
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/types/QueryResult.java
+++ b/src/main/java/com/surrealdb/refactor/types/QueryResult.java
@@ -1,10 +1,9 @@
 package com.surrealdb.refactor.types;
 
 import com.surrealdb.refactor.types.surrealdb.Value;
+import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.List;
 
 @Getter
 @ToString

--- a/src/main/java/com/surrealdb/refactor/types/QueryResult.java
+++ b/src/main/java/com/surrealdb/refactor/types/QueryResult.java
@@ -1,0 +1,21 @@
+package com.surrealdb.refactor.types;
+
+import com.surrealdb.refactor.types.surrealdb.Value;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class QueryResult {
+    private final List<Value> result;
+    private final String status;
+    private final String time;
+
+    public QueryResult(List<Value> result, String status, String time) {
+        this.result = result;
+        this.status = status;
+        this.time = time;
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/types/surrealdb/Number.java
+++ b/src/main/java/com/surrealdb/refactor/types/surrealdb/Number.java
@@ -1,10 +1,8 @@
 package com.surrealdb.refactor.types.surrealdb;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-
 import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @ToString
 @EqualsAndHashCode
@@ -16,11 +14,10 @@ public class Number {
     }
 
     public boolean isFloat() {
-        return _float!=null;
+        return _float != null;
     }
 
     public Optional<Float> asFloat() {
         return Optional.ofNullable(_float);
     }
-
 }

--- a/src/main/java/com/surrealdb/refactor/types/surrealdb/Number.java
+++ b/src/main/java/com/surrealdb/refactor/types/surrealdb/Number.java
@@ -1,9 +1,24 @@
 package com.surrealdb.refactor.types.surrealdb;
 
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Optional;
+
+@ToString
 public class Number {
-    private final float _float;
+    private final Float _float;
 
     public Number(float v) {
         _float = v;
     }
+
+    public boolean isFloat() {
+        return _float!=null;
+    }
+
+    public Optional<Float> asFloat() {
+        return Optional.ofNullable(_float);
+    }
+
 }

--- a/src/main/java/com/surrealdb/refactor/types/surrealdb/Number.java
+++ b/src/main/java/com/surrealdb/refactor/types/surrealdb/Number.java
@@ -1,11 +1,13 @@
 package com.surrealdb.refactor.types.surrealdb;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 import java.util.Optional;
 
 @ToString
+@EqualsAndHashCode
 public class Number {
     private final Float _float;
 

--- a/src/main/java/com/surrealdb/refactor/types/surrealdb/ObjectValue.java
+++ b/src/main/java/com/surrealdb/refactor/types/surrealdb/ObjectValue.java
@@ -1,0 +1,18 @@
+package com.surrealdb.refactor.types.surrealdb;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Map;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class ObjectValue {
+    private final Map<String, Value> values;
+
+    public ObjectValue(Map<String, Value> values) {
+        this.values = values;
+    }
+}

--- a/src/main/java/com/surrealdb/refactor/types/surrealdb/ObjectValue.java
+++ b/src/main/java/com/surrealdb/refactor/types/surrealdb/ObjectValue.java
@@ -1,10 +1,9 @@
 package com.surrealdb.refactor.types.surrealdb;
 
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.Map;
 
 @Getter
 @ToString

--- a/src/main/java/com/surrealdb/refactor/types/surrealdb/Value.java
+++ b/src/main/java/com/surrealdb/refactor/types/surrealdb/Value.java
@@ -4,8 +4,11 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.types.IntoJson;
+import lombok.ToString;
+
 import java.util.Optional;
 
+@ToString
 public class Value implements IntoJson {
 
     private final String string;

--- a/src/main/java/com/surrealdb/refactor/types/surrealdb/Value.java
+++ b/src/main/java/com/surrealdb/refactor/types/surrealdb/Value.java
@@ -35,7 +35,7 @@ public class Value implements IntoJson {
     }
 
     public boolean isString() {
-        return string == null;
+        return string != null;
     }
 
     public Optional<String> asString() {
@@ -52,7 +52,16 @@ public class Value implements IntoJson {
 
     @Override
     public JsonElement intoJson() {
-        return null;
+        if (isNumber()) {
+            return new JsonPrimitive(asNumber().get().asFloat().get());
+        }
+        if (isString()) {
+            return new JsonPrimitive(asString().get());
+        }
+        System.out.printf("This is value causing failure: %s\n", this);
+        throw new SurrealDBUnimplementedException(
+                "https://github.com/surrealdb/surrealdb.java/issues/63",
+                "Parsing general values from JSON is not implemented yet.");
     }
 
     public static Value fromJson(JsonElement json) {

--- a/src/main/java/com/surrealdb/refactor/types/surrealdb/Value.java
+++ b/src/main/java/com/surrealdb/refactor/types/surrealdb/Value.java
@@ -4,15 +4,18 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.types.IntoJson;
+import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import java.util.Optional;
 
 @ToString
+@EqualsAndHashCode
 public class Value implements IntoJson {
 
     private final String string;
     private final Number number;
+    private final ObjectValue object;
 
     /**
      * Create a Value that represents a Strand type
@@ -22,6 +25,7 @@ public class Value implements IntoJson {
     public Value(String string) {
         this.string = string;
         this.number = null;
+        this.object = null;
     }
 
     /**
@@ -32,6 +36,13 @@ public class Value implements IntoJson {
     public Value(Number number) {
         this.string = null;
         this.number = number;
+        this.object = null;
+    }
+
+    public Value(ObjectValue object) {
+        this.string = null;
+        this.number = null;
+        this.object = object;
     }
 
     public boolean isString() {

--- a/src/main/java/com/surrealdb/refactor/types/surrealdb/Value.java
+++ b/src/main/java/com/surrealdb/refactor/types/surrealdb/Value.java
@@ -4,10 +4,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.surrealdb.refactor.exception.SurrealDBUnimplementedException;
 import com.surrealdb.refactor.types.IntoJson;
+import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-
-import java.util.Optional;
 
 @ToString
 @EqualsAndHashCode

--- a/src/test/java/com/surrealdb/refactor/driver/parsing/JsonQueryResultParserTest.java
+++ b/src/test/java/com/surrealdb/refactor/driver/parsing/JsonQueryResultParserTest.java
@@ -1,0 +1,45 @@
+package com.surrealdb.refactor.driver.parsing;
+
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.surrealdb.refactor.types.QueryResult;
+import com.surrealdb.refactor.types.surrealdb.ObjectValue;
+import com.surrealdb.refactor.types.surrealdb.Value;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonQueryResultParserTest {
+
+    @Test
+    public void regular_result() {
+        String rawJson = """
+                {"result":[{"id":"person:lamport","name":"leslie"}],"status":"OK","time":"438.583µs"}
+                """;
+
+        JsonElement jsonElement = JsonParser.parseString(rawJson);
+        QueryResult res = new JsonQueryResultParser().parse(jsonElement);
+
+        assertEquals("OK", res.getStatus());
+        assertEquals("438.583µs", res.getTime());
+        Value expectedValue = new Value(new ObjectValue(asMap(
+                Tuple.of("id", new Value("person:lamport")),
+                Tuple.of("name", new Value("leslie"))
+        )));
+        assertArrayEquals(new Value[] {expectedValue}, res.getResult().toArray(new Value[0]));
+    }
+
+    private static Map<String, Value> asMap(Tuple<String, Value>... data) {
+        Map<String, Value> obj = new HashMap<>();
+        for (Tuple<String, Value> entry : data) {
+            obj.put(entry.key, entry.value);
+        }
+        return obj;
+    }
+}

--- a/src/test/java/com/surrealdb/refactor/driver/parsing/JsonQueryResultParserTest.java
+++ b/src/test/java/com/surrealdb/refactor/driver/parsing/JsonQueryResultParserTest.java
@@ -1,25 +1,23 @@
 package com.surrealdb.refactor.driver.parsing;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.surrealdb.refactor.types.QueryResult;
 import com.surrealdb.refactor.types.surrealdb.ObjectValue;
 import com.surrealdb.refactor.types.surrealdb.Value;
-import org.junit.jupiter.api.Test;
-
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class JsonQueryResultParserTest {
 
     @Test
     public void regular_result() {
-        String rawJson = """
+        String rawJson =
+                """
                 {"result":[{"id":"person:lamport","name":"leslie"}],"status":"OK","time":"438.583µs"}
                 """;
 
@@ -28,10 +26,12 @@ public class JsonQueryResultParserTest {
 
         assertEquals("OK", res.getStatus());
         assertEquals("438.583µs", res.getTime());
-        Value expectedValue = new Value(new ObjectValue(asMap(
-                Tuple.of("id", new Value("person:lamport")),
-                Tuple.of("name", new Value("leslie"))
-        )));
+        Value expectedValue =
+                new Value(
+                        new ObjectValue(
+                                asMap(
+                                        Tuple.of("id", new Value("person:lamport")),
+                                        Tuple.of("name", new Value("leslie")))));
         assertArrayEquals(new Value[] {expectedValue}, res.getResult().toArray(new Value[0]));
     }
 

--- a/src/test/java/com/surrealdb/refactor/driver/parsing/Tuple.java
+++ b/src/test/java/com/surrealdb/refactor/driver/parsing/Tuple.java
@@ -1,0 +1,15 @@
+package com.surrealdb.refactor.driver.parsing;
+
+public class Tuple<K, V> {
+    final K key;
+    final V value;
+
+    private Tuple(K key, V value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public static <K, V> Tuple<K, V> of(K key, V value) {
+        return new Tuple<>(key, value);
+    }
+}


### PR DESCRIPTION
Add implementation for WebSocket rewrite for the query method.
The query method is favoured over the others because it is the most general-purpose endpoint/method allowing for all queries to be performed.