### PR TITLE
Add upload of artifacts to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: fatJar
+
+      - name: Upload Artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-output
+          path: /home/runner/work/surrealdb.java/surrealdb.java/build


### PR DESCRIPTION
Add a workflow step to test that uploads the test artifacts (HTML test report). This should be accessible in builds.

The build output can be found in the summary of every build.