### PR TITLE
This attempts to fix issue #75:

### DIFF
--- a/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
+++ b/src/main/java/com/surrealdb/refactor/driver/WsPlaintextConnection.java
@@ -80,8 +80,21 @@ public class WsPlaintextConnection {
                                 }
                                 JsonElement outerResultJson = resp.get("result");
                                 QueryResult[] processedOuterResults;
-                                if (outerResultJson.isJsonArray()) {
-                                    JsonArray outerResultArray = outerResultJson.getAsJsonArray();
+
+                                // checks to see if result is a JSON element, if not throw exception
+                                if (outerResultJson.isJsonObject()) {
+                                    JsonArray outerResultArray;
+
+                                    if (!outerResultJson.isJsonArray()) {
+
+                                        // add element to an array if it is not an array
+                                        outerResultArray = new JsonArray();
+                                        outerResultArray.add(outerResultJson);
+                                    } else {
+
+                                        outerResultArray = outerResultJson.getAsJsonArray();
+                                    }
+
                                     processedOuterResults =
                                             new QueryResult[outerResultArray.size()];
                                     for (int i = 0; i < outerResultArray.size(); i++) {
@@ -95,9 +108,12 @@ public class WsPlaintextConnection {
                                         processedOuterResults[i] = val;
                                     }
                                 } else {
+                                    // exception is now thrown if results are not a Json Element
+                                    // instead of Json Array
+
                                     throw new SurrealDBUnimplementedException(
                                             "https://github.com/surrealdb/surrealdb.java/issues/75",
-                                            "The response contained results that were not in an array");
+                                            "The response contained results that were not a Json Element");
                                 }
                                 return new QueryBlockResult(Arrays.asList(processedOuterResults));
                             }


### PR DESCRIPTION
Feature: Handle query returning single responses in the websocket protocol issue #75 

This commit incorporates allowing the user to pass a Json element that is not necessarily an array. The code will add the element (for example, a person) into a newly instantiated array if the Json element is not already an array.

Instead of throwing an error if the result is not an array, now an error is thrown if the result is not a JSON element.

The main altered code starts on line 85. I am new to adding to projects, and I am not sure why the code doesn't recognize which lines are added/changed. Instead it just says the entire file is new.

The build with gradle initially failed and gave me a prompt to run the command gradlew.bat :spotlessApply . Afterwards the program was able to build successfully with the command gradlew build.

Since I am new, can you offer me any feedback on how I did? Was this what you were looking for?