### PR TITLE
Initial commit for SDK With Repository pattern

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.surrealdb'
-version '0.1.0'
+version '0.1.1'
 
 repositories {
     mavenCentral()
@@ -51,6 +51,10 @@ dependencies {
 
     // Gson
     implementation 'com.google.code.gson:gson:2.9.1'
+
+    //spring
+    implementation 'org.springframework:spring-webmvc:5.3.20'
+    implementation 'org.reflections:reflections:0.10.2'
 
     // logging
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"

--- a/src/main/java/com/surrealdb/config/RepositoryInitializer.java
+++ b/src/main/java/com/surrealdb/config/RepositoryInitializer.java
@@ -1,0 +1,116 @@
+package com.surrealdb.config;
+
+import com.surrealdb.driver.model.QueryResult;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.*;
+import org.springframework.context.annotation.Configuration;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.surrealdb.config.SurrealDBConnection.getRepoDriver;
+
+@Configuration
+public class RepositoryInitializer implements BeanDefinitionRegistryPostProcessor {
+    public Set<Class<? extends SurrealCrudRepository>> findSurrealCrudRepositories(String packageName) {
+        Reflections reflections = new Reflections(new ConfigurationBuilder()
+            .setUrls(ClasspathHelper.forPackage(packageName))
+            .setScanners(new SubTypesScanner(false)));
+
+        return reflections.getSubTypesOf(SurrealCrudRepository.class);
+    }
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+        Set<Class<? extends SurrealCrudRepository>> allClasses = findSurrealCrudRepositories("");
+        for (Class<? extends SurrealCrudRepository> repoClass : allClasses) {
+            Type[] genericInterfaces = repoClass.getGenericInterfaces();
+            for (Type genericInterface : genericInterfaces) {
+                if (genericInterface instanceof ParameterizedType) {
+                    ParameterizedType parameterizedType = (ParameterizedType) genericInterface;
+                    if (parameterizedType.getRawType().equals(SurrealCrudRepository.class)) {
+                        Type[] typeArguments = parameterizedType.getActualTypeArguments();
+                        if (typeArguments.length == 2) {
+                            Type entityType = typeArguments[0];
+                            Class<?> entityClass = null;
+                            if (entityType instanceof Class<?>) {
+                                entityClass = (Class<?>) entityType;
+                            }
+                            registerRepositoryBean(entityClass, registry, repoClass);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private <T, ID, R extends SurrealCrudRepository<T, ID>> void registerRepositoryBean(Class<T> entityType, BeanDefinitionRegistry registry, Class<R> repositoryClass) {
+        ProxyFactory proxyFactory = new ProxyFactory();
+        proxyFactory.addInterface(repositoryClass);
+        SurrealCrudRepositoryImpl<T, ID> target = new SurrealCrudRepositoryImpl<>(entityType);
+
+        proxyFactory.addAdvice((MethodInterceptor) invocation -> {
+            Method method = invocation.getMethod();
+            if (method.isAnnotationPresent(SurrealQuery.class)) {
+                String query = method.getAnnotation(SurrealQuery.class).value();
+                Object[] args = invocation.getArguments();
+                Pattern pattern = Pattern.compile("\\?(\\d+)");
+                Matcher matcher = pattern.matcher(query);
+                StringBuffer sb = new StringBuffer();
+                while (matcher.find()) {
+                    int index = Integer.parseInt(matcher.group(1)) - 1;
+                    if (index < args.length) {
+                        String replacement = args[index] instanceof String ? "'" + args[index] + "'" : args[index].toString();
+                        matcher.appendReplacement(sb, replacement);
+                    } else {
+                        throw new SQLException("Argument index out of bounds: " + (index + 1));
+                    }
+                }
+                matcher.appendTail(sb);
+                String processedQuery = sb.toString();
+                Type returnType = method.getGenericReturnType();
+                if (returnType instanceof ParameterizedType) {
+                    Type[] typeArguments = ((ParameterizedType) returnType).getActualTypeArguments();
+                    if (typeArguments.length > 0 && typeArguments[0] instanceof Class<?> genericClass) {
+                        return getRepoDriver().query(processedQuery, Collections.emptyMap(), genericClass);
+                    }
+                } else {
+                    List<QueryResult<T>> results = getRepoDriver().query(processedQuery, Collections.emptyMap(), (Class<? extends T>) returnType);
+                    var result = results.stream()
+                        .flatMap(qr -> qr.getResult().stream())
+                        .toList();
+                    return result.get(0);
+                }
+                throw new SQLException("Unsupported return type for method: " + method.getName());
+            } else {
+                return invocation.getMethod().invoke(target, invocation.getArguments());
+            }
+        });
+
+        R repositoryProxy = (R) proxyFactory.getProxy();
+        AbstractBeanDefinition beanDefinition = BeanDefinitionBuilder
+            .genericBeanDefinition(repositoryClass, () -> repositoryProxy)
+            .getBeanDefinition();
+
+        registry.registerBeanDefinition(repositoryClass.getSimpleName(), beanDefinition);
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+    }
+
+}

--- a/src/main/java/com/surrealdb/config/RepositoryInitializerAutoConfiguration.java
+++ b/src/main/java/com/surrealdb/config/RepositoryInitializerAutoConfiguration.java
@@ -1,0 +1,13 @@
+package com.surrealdb.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RepositoryInitializerAutoConfiguration {
+
+    @Bean
+    public static RepositoryInitializer repositoryInitializer() {
+        return new RepositoryInitializer();
+    }
+}

--- a/src/main/java/com/surrealdb/config/SequenceEntity.java
+++ b/src/main/java/com/surrealdb/config/SequenceEntity.java
@@ -1,0 +1,13 @@
+package com.surrealdb.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Data
+@NoArgsConstructor
+public class SequenceEntity {
+    String id;
+    Long seq_value;
+}

--- a/src/main/java/com/surrealdb/config/SurrealCrudRepository.java
+++ b/src/main/java/com/surrealdb/config/SurrealCrudRepository.java
@@ -1,0 +1,12 @@
+package com.surrealdb.config;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SurrealCrudRepository<T, ID> {
+    Optional<T> findById(ID id);
+    List<T> findAll();
+    T save(T entity);
+    void delete(T entity);
+    T update(T entity);
+}

--- a/src/main/java/com/surrealdb/config/SurrealCrudRepositoryImpl.java
+++ b/src/main/java/com/surrealdb/config/SurrealCrudRepositoryImpl.java
@@ -1,0 +1,142 @@
+package com.surrealdb.config;
+
+import com.surrealdb.driver.SyncSurrealDriver;
+import com.surrealdb.driver.model.QueryResult;
+import com.surrealdb.refactor.exception.MissingSurrealTableAnnotationException;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.surrealdb.config.SurrealDBConnection.getRepoDriver;
+
+public class SurrealCrudRepositoryImpl<T, ID> implements SurrealCrudRepository<T, ID> {
+
+    private final Class<T> entityType;
+    SyncSurrealDriver driver = getRepoDriver();
+    private final String tableName;
+
+    public SurrealCrudRepositoryImpl(Class<T> entityType) {
+        this.entityType = entityType;
+        this.tableName = resolveTableName(entityType);
+    }
+
+    private static String resolveTableName(Class<?> entityType) {
+        if (!entityType.isAnnotationPresent(SurrealTable.class)) {
+            throw new MissingSurrealTableAnnotationException(entityType);
+        }
+        return entityType.getAnnotation(SurrealTable.class).value();
+    }
+
+    @Override
+    public Optional<T> findById(ID id) {
+        String query = String.format("select * from %s where id = '%s';", tableName, id.toString());
+        List<QueryResult<T>> response = driver.query(query, Collections.emptyMap(), entityType);
+        if (response == null || response.isEmpty()) {
+            return Optional.empty();
+        }
+        List<T> res = response.stream()
+                .flatMap(qr -> qr.getResult().stream())
+                .toList();
+        if (!res.isEmpty()) {
+            return Optional.ofNullable(res.get(0));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<T> findAll() {
+        String query = String.format("select * from %s;", tableName);
+        List<QueryResult<T>> response = driver.query(query, Collections.emptyMap(), entityType);
+        if (response == null || response.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return response.stream()
+                .flatMap(qr -> qr.getResult().stream())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public T save(T entity) {
+        processSequenceIds(entity);
+        return driver.create(tableName, entity);
+    }
+
+    private void processSequenceIds(T entity) {
+        for (Field field : entity.getClass().getDeclaredFields()) {
+            if (field.isAnnotationPresent(SurrealSequenceId.class)) {
+                field.setAccessible(true);
+                try {
+                    Object currentValue = field.get(entity);
+                    if (currentValue == null) {
+                        String sequenceName = field.getAnnotation(SurrealSequenceId.class).sequenceName();
+                        Long nextIdValue = generateRouteId(sequenceName);
+                        if (field.getType().equals(String.class)) {
+                            field.set(entity, String.valueOf(nextIdValue));
+                        } else if (field.getType().equals(Long.class) || field.getType().equals(long.class)) {
+                            field.set(entity, nextIdValue);
+                        } else if (field.getType().equals(Integer.class) || field.getType().equals(int.class)) {
+                            field.set(entity, nextIdValue.intValue());
+                        } else {
+                            throw new IllegalArgumentException("Unsupported field type for @SurrealSequenceId: " + field.getType());
+                        }
+                    }
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException("Failed to access or set value for @SurrealSequenceId field", e);
+                }
+            }
+        }
+    }
+
+    private Long generateRouteId(String sequenceName) {
+        String sequenceKey = "sequence:" + tableName + sequenceName;
+        List<QueryResult<SequenceEntity>> response = driver.query(String.format("select seq_value from %s;", sequenceKey), Collections.emptyMap(), SequenceEntity.class);
+        List<SequenceEntity> res = response.stream()
+                .flatMap(qr -> qr.getResult().stream())
+                .toList();
+        if (res.isEmpty()) {
+            return createNewSequence(sequenceKey);
+        }
+        Long currentValue = res.get(0).getSeq_value() + 1;
+        driver.query(String.format("update %s set seq_value = %d;", sequenceKey, currentValue), Collections.emptyMap(), Object.class);
+        return currentValue;
+
+    }
+
+    private Long createNewSequence(String sequenceKey) {
+        driver.query(String.format("create %s SET seq_value = 1", sequenceKey), Collections.emptyMap(), Object.class);
+        return 1L;
+    }
+
+    @Override
+    public void delete(T entity) {
+        driver.delete(getIdFromEntity(entity));
+    }
+
+    @Override
+    public T update(T entity) {
+        return driver.update(getIdFromEntity(entity), entity).get(0);
+    }
+
+    private String getIdFromEntity(T entity) {
+        for (Field field : entity.getClass().getDeclaredFields()) {
+            if (field.isAnnotationPresent(SurrealId.class)) {
+                try {
+                    field.setAccessible(true);
+                    Object value = field.get(entity);
+                    if (value != null) {
+                        return value.toString();
+                    } else {
+                        return null;
+                    }
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException("Failed to access @SurrealId field value", e);
+                }
+            }
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/com/surrealdb/config/SurrealDBConnection.java
+++ b/src/main/java/com/surrealdb/config/SurrealDBConnection.java
@@ -1,0 +1,45 @@
+package com.surrealdb.config;
+
+import com.surrealdb.connection.SurrealConnection;
+import com.surrealdb.connection.SurrealWebSocketConnection;
+import com.surrealdb.driver.SyncSurrealDriver;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class SurrealDBConnection {
+    private static SyncSurrealDriver driver = null;
+    private static final String PROPERTIES_FILE = "/application.properties";
+    private static final String host;
+    private static final int port;
+    private static final boolean useSsl;
+    private static final String nameSpace;
+    private static final String database;
+
+    static {
+        Properties properties = new Properties();
+        try {
+            properties.load(SurrealDBConnection.class.getResourceAsStream(PROPERTIES_FILE));
+            host = properties.getProperty("surrealdb.host", "localhost");
+            port = Integer.parseInt(properties.getProperty("surrealdb.port", "8000"));
+            useSsl = Boolean.parseBoolean(properties.getProperty("surrealdb.useSsl", "false"));
+            nameSpace = properties.getProperty("surrealdb.nameSpace", "test");
+            database = properties.getProperty("surrealdb.database", "test") ;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load surrealdb.properties", e);
+        }
+    }
+
+    private SurrealDBConnection() {
+    }
+
+    public static synchronized SyncSurrealDriver getRepoDriver() {
+        if (driver == null) {
+            SurrealConnection conn = new SurrealWebSocketConnection(host, port, useSsl);
+            conn.connect(5);
+            driver = new SyncSurrealDriver(conn);
+            driver.use(nameSpace, database);
+        }
+        return driver;
+    }
+}

--- a/src/main/java/com/surrealdb/config/SurrealId.java
+++ b/src/main/java/com/surrealdb/config/SurrealId.java
@@ -1,0 +1,12 @@
+package com.surrealdb.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface SurrealId {
+}
+

--- a/src/main/java/com/surrealdb/config/SurrealQuery.java
+++ b/src/main/java/com/surrealdb/config/SurrealQuery.java
@@ -1,0 +1,12 @@
+package com.surrealdb.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface SurrealQuery {
+    String value();
+}

--- a/src/main/java/com/surrealdb/config/SurrealSequenceId.java
+++ b/src/main/java/com/surrealdb/config/SurrealSequenceId.java
@@ -1,0 +1,11 @@
+package com.surrealdb.config;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface SurrealSequenceId {
+    String sequenceName();
+}

--- a/src/main/java/com/surrealdb/config/SurrealTable.java
+++ b/src/main/java/com/surrealdb/config/SurrealTable.java
@@ -1,0 +1,13 @@
+package com.surrealdb.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface SurrealTable {
+    String value();
+}
+


### PR DESCRIPTION
#82 
I raised this feature request a couple of days back. 
As you guys mentioned that you are open to ideas, here is an approach which can help spring developers to easily integrate surrealdb with their existing system. 

I have created an implementation which will expect the following to use repository pattern  (The library still works as it is if this is not required) ->

1.  Configuration through application.properties (else it will take the default values, will add id and password as well) :


> surrealdb.host=localhost
> surrealdb.port=8000
> surrealdb.useSsl=false
> surrealdb.nameSpace=test
> surrealdb.database=test


2.  Entity Annotation with @SurrealTable and @SurrealId: Entities can now be annotated to define document/table mappings and identifiers, simplifying the mapping process. For example:

```
@SurrealTable("parent_route")
@AllArgsConstructor
@Data
@NoArgsConstructor
public class ParentRoute {

    @SurrealId
    private String id;
    private Long validFrom;
    private Long validTo;
    private String client;
    private String rId;

 } 
```

3. CRUD Operations through SurrealCrudRepository: Entities can extend the SurrealCrudRepository interface to enable CRUD operations, streamlining data manipulation tasks:

```
@Repository
public interface ParentRouteRepository extends SurrealCrudRepository<ParentRoute,String> {
}
```

4. Custom Queries with @SurrealQuery: Similar to JPA's @Query annotation, @SurrealQuery enables the execution of custom queries, providing flexibility in data retrieval:

```
@Repository
public interface ParentRouteRepository extends SurrealCrudRepository<ParentRoute,String> {

    @SurrealQuery("select * from parent_route where client = ?1 and rId = ?2 ;")
    ParentRoute findByRouteIdAndBuid(String client, String rId);
    
    
    @SurrealQuery("select *, ->hasData->(r_data where time = ?1 ).*->hasVehicle->vehicle_detail.* as vehicle from parent_route where client = ?2 and rId = ?3 ;")
    List<ParentRoutePrj> findShuttleRouteByStartTimeAndBuidAndRouteId(long time, String client, String rId);
    
}
```

Extra feature in first cut -> 
If we want a field to have a sequence we can use @SurrealSequenceId(sequenceName = "rIdSequence") : This will give that field a numeric sequence (with string-type fields being appropriately casted).
