### PR TITLE
Value related improvements and additions

### DIFF
--- a/src/main/java/com/surrealdb/Id.java
+++ b/src/main/java/com/surrealdb/Id.java
@@ -1,5 +1,7 @@
 package com.surrealdb;
 
+import java.util.UUID;
+
 /**
  * The Id class represents a unique identifier that can be either a long value or a string.
  */
@@ -17,9 +19,15 @@ public class Id extends Native {
         return new Id(newStringId(id));
     }
 
+    public static Id from(UUID id) {
+        return new Id(newUuidId(id.toString()));
+    }
+
     private static native long newLongId(long id);
 
     private static native long newStringId(String id);
+
+    private static native long newUuidId(String id);
 
     private static native boolean isLong(long ptr);
 
@@ -28,6 +36,10 @@ public class Id extends Native {
     private static native boolean isString(long ptr);
 
     private static native String getString(long ptr);
+
+    private static native boolean isUuid(long ptr);
+
+    private static native String getUuid(long ptr);
 
     private static native boolean isArray(long ptr);
 
@@ -63,6 +75,14 @@ public class Id extends Native {
 
     final public String getString() {
         return getString(getPtr());
+    }
+
+    final public boolean isUuid() {
+        return isUuid(getPtr());
+    }
+
+    final public UUID getUuid() {
+        return UUID.fromString(getUuid(getPtr()));
     }
 
     final public boolean isArray() {

--- a/src/main/java/com/surrealdb/RecordId.java
+++ b/src/main/java/com/surrealdb/RecordId.java
@@ -1,5 +1,7 @@
 package com.surrealdb;
 
+import java.util.UUID;
+
 /**
  * The RecordId class represents a unique identifier for a record in a database.
  * <p>
@@ -22,9 +24,15 @@ public class RecordId extends Native {
         super(newThingStringId(table, id));
     }
 
+    public RecordId(String table, UUID id) {
+        super(newThingUuidId(table, id.toString()));
+    }
+
     private static native long newThingLongId(String table, long id);
 
     private static native long newThingStringId(String table, String id);
+
+    private static native long newThingUuidId(String table, String id);
 
     private static native String getTable(long ptr);
 

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -92,9 +92,11 @@ class ValueBuilder {
         if (fields.length > 0) {
             final List<EntryMut> entries = new ArrayList<>(fields.length);
             for (final Field field : fields) {
-                if (Modifier.isStatic(field.getModifiers())) {
+                int mods = field.getModifiers();
+                if (Modifier.isStatic(mods) || Modifier.isTransient(mods)) {
                     continue;
                 }
+                field.setAccessible(true);
                 final String name = field.getName();
                 final java.lang.Object value = field.get(object);
                 if (value != null) {

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -14,7 +14,7 @@ class ValueBuilder {
 
     private static <T> ValueMut convertObject(final T object) throws IllegalAccessException {
         if (object == null) {
-            return null;
+            return ValueMut.createNull();
         }
         if (object instanceof ValueMut) {
             return (ValueMut) object;
@@ -93,9 +93,9 @@ class ValueBuilder {
                     continue;
                 }
                 final String name = field.getName();
-                final ValueMut value = convert(field.get(object));
+                final java.lang.Object value = field.get(object);
                 if (value != null) {
-                    entries.add(EntryMut.newEntry(name, value));
+                    entries.add(EntryMut.newEntry(name, convert(value)));
                 }
             }
             return ValueMut.createObject(entries);

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -79,6 +79,12 @@ class ValueBuilder {
         if (object instanceof RecordId) {
             return ValueMut.createThing((RecordId) object);
         }
+        if (object instanceof Array) {
+            return ValueMut.createArray((Array) object);
+        }
+        if (object instanceof Object) {
+            return ValueMut.createObject((Object) object);
+        }
         final Field[] fields = object.getClass().getDeclaredFields();
         if (fields.length > 0) {
             final List<EntryMut> entries = new ArrayList<>(fields.length);

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -6,10 +6,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 
@@ -60,6 +57,17 @@ class ValueBuilder {
             // Create a ValueMut for each element of the collection
             final List<ValueMut> values = collection.stream().map(ValueBuilder::convert).collect(Collectors.toList());
             return ValueMut.createArray(values);
+        }
+        if (object instanceof Map) {
+            final Map<?, ?> map = (Map<?, ?>) object;
+            final List<EntryMut> entries = new ArrayList<>(map.size());
+            // Create a ValueMut for each value of the map
+            for (final Map.Entry<?, ?> entry : map.entrySet()) {
+                final String key = entry.getKey().toString();
+                final ValueMut value = convert(entry.getValue());
+                entries.add(EntryMut.newEntry(key, value));
+            }
+            return ValueMut.createObject(entries);
         }
         if (object instanceof Optional) {
             final Optional<?> optional = (Optional<?>) object;

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -76,6 +76,9 @@ class ValueBuilder {
         if (object instanceof Id) {
             return ValueMut.createId((Id) object);
         }
+        if (object instanceof UUID) {
+            return ValueMut.createUuid((UUID) object);
+        }
         if (object instanceof RecordId) {
             return ValueMut.createThing((RecordId) object);
         }

--- a/src/main/java/com/surrealdb/ValueMut.java
+++ b/src/main/java/com/surrealdb/ValueMut.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.UUID;
 
 public class ValueMut extends Native {
 
@@ -28,6 +29,8 @@ public class ValueMut extends Native {
     private static native long newDuration(long l);
 
     private static native long newDatetime(long seconds, long nanos);
+
+    private static native long newUuid(String s);
 
     private static native long newId(long ptr);
 
@@ -75,6 +78,10 @@ public class ValueMut extends Native {
 
     public static ValueMut createDatetime(ZonedDateTime d) {
         return new ValueMut(newDatetime(d.toEpochSecond(), d.getNano()));
+    }
+
+    public static ValueMut createUuid(UUID uuid) {
+        return new ValueMut(newUuid(uuid.toString()));
     }
 
     public static ValueMut createId(Id id) {

--- a/src/main/java/com/surrealdb/ValueMut.java
+++ b/src/main/java/com/surrealdb/ValueMut.java
@@ -33,9 +33,13 @@ public class ValueMut extends Native {
 
     private static native long newThing(long ptr);
 
-    private static native long newArray(long[] ptrs);
+    private static native long newArray(long ptr);
 
-    private static native long newObject(long[] ptrs);
+    private static native long newArrayOf(long[] ptrs);
+
+    private static native long newObject(long ptr);
+
+    private static native long newObjectOf(long[] ptrs);
 
     public static ValueMut createNone() {
         return new ValueMut(newNone());
@@ -81,6 +85,10 @@ public class ValueMut extends Native {
         return new ValueMut(newThing(recordId.getPtr()));
     }
 
+    public static ValueMut createArray(Array array) {
+        return new ValueMut(newArray(array.getPtr()));
+    }
+
     public static ValueMut createArray(List<ValueMut> values) {
         final long[] ptrs = new long[values.size()];
         int idx = 0;
@@ -88,10 +96,14 @@ public class ValueMut extends Native {
         for (final ValueMut value : values) {
             ptrs[idx++] = value.getPtr();
         }
-        final ValueMut value = new ValueMut(newArray(ptrs));
+        final ValueMut value = new ValueMut(newArrayOf(ptrs));
         // The Values have been moved
         values.forEach(Native::moved);
         return value;
+    }
+
+    public static ValueMut createObject(Object object) {
+        return new ValueMut(newObject(object.getPtr()));
     }
 
     public static ValueMut createObject(List<EntryMut> entries) {
@@ -101,7 +113,7 @@ public class ValueMut extends Native {
         for (final EntryMut entry : entries) {
             ptrs[idx++] = entry.getPtr();
         }
-        final ValueMut value = new ValueMut(newObject(ptrs));
+        final ValueMut value = new ValueMut(newObjectOf(ptrs));
         // The Entries have been moved
         entries.forEach(Native::moved);
         return value;

--- a/src/main/rust/valuemut.rs
+++ b/src/main/rust/valuemut.rs
@@ -146,6 +146,19 @@ pub extern "system" fn Java_com_surrealdb_ValueMut_newThing<'local>(
 pub extern "system" fn Java_com_surrealdb_ValueMut_newArray<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
+    ptr: jlong,
+) -> jlong {
+    let value = get_value_instance!(&mut env, ptr, || 0);
+    if matches!(value.as_ref(), Value::Array(_)) {
+        return JniTypes::new_value_mut(value.as_ref().clone());
+    }
+    SurrealError::NullPointerException("Array").exception(&mut env, || 0)
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_ValueMut_newArrayOf<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
     ptrs: JLongArray<'local>,
 ) -> jlong {
     let ptrs = get_long_array!(&mut env, &ptrs, || 0);
@@ -160,6 +173,19 @@ pub extern "system" fn Java_com_surrealdb_ValueMut_newArray<'local>(
 
 #[no_mangle]
 pub extern "system" fn Java_com_surrealdb_ValueMut_newObject<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    ptr: jlong,
+) -> jlong {
+    let value = get_value_instance!(&mut env, ptr, || 0);
+    if matches!(value.as_ref(), Value::Object(_)) {
+        return JniTypes::new_value_mut(value.as_ref().clone());
+    }
+    SurrealError::NullPointerException("Object").exception(&mut env, || 0)
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_ValueMut_newObjectOf<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
     ptrs: JLongArray<'local>,

--- a/src/main/rust/valuemut.rs
+++ b/src/main/rust/valuemut.rs
@@ -8,7 +8,7 @@ use jni::objects::{JClass, JLongArray, JString};
 use jni::sys::{jboolean, jdouble, jint, jlong, jstring};
 use jni::JNIEnv;
 use rust_decimal::Decimal;
-use surrealdb::sql::{Array, Datetime, Duration, Number, Object, Strand, Value};
+use surrealdb::sql::{Array, Datetime, Duration, Number, Object, Strand, Uuid, Value};
 
 use crate::error::SurrealError;
 use crate::{
@@ -21,7 +21,7 @@ pub extern "system" fn Java_com_surrealdb_ValueMut_newNone<'local>(
     _env: JNIEnv<'local>,
     _class: JClass<'local>,
 ) -> jlong {
-    create_instance(Value::None,JniTypes::ValueMut)
+    create_instance(Value::None, JniTypes::ValueMut)
 }
 
 #[no_mangle]
@@ -29,7 +29,7 @@ pub extern "system" fn Java_com_surrealdb_ValueMut_newNull<'local>(
     _env: JNIEnv<'local>,
     _class: JClass<'local>,
 ) -> jlong {
-    create_instance(Value::Null,JniTypes::ValueMut)
+    create_instance(Value::Null, JniTypes::ValueMut)
 }
 
 #[no_mangle]
@@ -127,6 +127,20 @@ pub extern "system" fn Java_com_surrealdb_ValueMut_newId<'local>(
         return JniTypes::new_value_mut(value.as_ref().clone());
     }
     SurrealError::NullPointerException("ID").exception(&mut env, || 0)
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_ValueMut_newUuid<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    s: JString<'local>,
+) -> jlong {
+    let s = get_rust_string!(&mut env, s, || 0);
+    if let Ok(uuid) = Uuid::from_str(&s) {
+        let value = Value::Uuid(uuid);
+        return create_instance(value, JniTypes::ValueMut);
+    }
+    SurrealError::NullPointerException("Uuid").exception(&mut env, || 0)
 }
 
 #[no_mangle]

--- a/src/test/java/com/surrealdb/TypeTests.java
+++ b/src/test/java/com/surrealdb/TypeTests.java
@@ -1,6 +1,7 @@
 package com.surrealdb;
 
 import com.surrealdb.pojos.Dates;
+import com.surrealdb.pojos.Name;
 import com.surrealdb.pojos.Numbers;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -53,6 +55,28 @@ public class TypeTests {
             final Dates created = surreal.create(Dates.class, "date", d).get(0);
             // We check that the records are matching
             assertEquals(created, d);
+        }
+    }
+
+    @Test
+    void testRecordIds() {
+        try (final Surreal surreal = new Surreal()) {
+            // Starts an embedded in memory instance
+            surreal.connect("memory").useNs("test_ns").useDb("test_db");
+            // Create content
+            final Name name = new Name("foo", "bar");
+            // Create record ids
+            final RecordId stringId = new RecordId("foo", "bar");
+            final RecordId numberId = new RecordId("foo", 25565L);
+            final RecordId uuidId = new RecordId("foo", UUID.randomUUID());
+            // We ingest the record
+            final Value created1 = surreal.create(stringId, name);
+            final Value created2 = surreal.create(numberId, name);
+            final Value created3 = surreal.create(uuidId, name);
+            // We check that the records are matching
+            assertEquals(created1.get(Name.class), name);
+            assertEquals(created2.get(Name.class), name);
+            assertEquals(created3.get(Name.class), name);
         }
     }
 


### PR DESCRIPTION
This PR fills some missing gaps in the Value related classes

- Support `Map` instances in ValueBuilder
- Support `UUID` instances in VueMut and ValueBuilder
- Support `Array` and `Object` instances in ValueBuilder
  - Useful when passing previous responses as arguments for another query
- Correctly handle null in ValueBuilder using `ValueMut.createNull()`
- Support `UUID` based record ids
- Include private fields in the `ValueBuilder`
- Exclude fields marked `transient` from the `ValueBuilder`

Included unit tests covering all added functionality