### PR TITLE
Fix JVM crash when accessing array-backed RecordId keys

### DIFF
--- a/src/main/java/com/surrealdb/Id.java
+++ b/src/main/java/com/surrealdb/Id.java
@@ -44,11 +44,11 @@ public class Id extends Native {
 
 	private static native boolean isArray(long ptr);
 
-	private static native Array getArray(long ptr);
+	private static native long getArray(long ptr);
 
 	private static native boolean isObject(long ptr);
 
-	private static native Object getObject(long ptr);
+	private static native long getObject(long ptr);
 
 	@Override
 	final native int hashCode(long ptr);
@@ -91,7 +91,7 @@ public class Id extends Native {
 	}
 
 	final public Array getArray() {
-		return getArray(getPtr());
+		return new Array(getArray(getPtr()));
 	}
 
 	final public boolean isObject() {
@@ -99,7 +99,7 @@ public class Id extends Native {
 	}
 
 	final public Object getObject() {
-		return getObject(getPtr());
+		return new Object(getObject(getPtr()));
 	}
 
 }

--- a/src/test/java/com/surrealdb/TypeTests.java
+++ b/src/test/java/com/surrealdb/TypeTests.java
@@ -92,6 +92,11 @@ public class TypeTests {
 			assertTrue(arrayValue.isArray());
 			Array keyArray = arrayValue.getArray();
 			RecordId rid = new RecordId("with_array_key", keyArray);
+			Id id = rid.getId();
+			assertTrue(id.isArray());
+			Array idArray = id.getArray();
+			assertEquals(3, idArray.len());
+			assertEquals(1, idArray.get(0).getLong());
 			final Name name = new Name("array", "key");
 			final Value created = surreal.create(rid, name);
 			assertEquals(created.get(Name.class), name);
@@ -110,6 +115,12 @@ public class TypeTests {
 			assertTrue(objValue.isObject());
 			Object keyObj = objValue.getObject();
 			RecordId rid = new RecordId("with_object_key", keyObj);
+			Id id = rid.getId();
+			assertTrue(id.isObject());
+			Object idObject = id.getObject();
+			assertEquals(2, idObject.len());
+			assertEquals(1, idObject.get("a").getLong());
+			assertEquals("two", idObject.get("b").getString());
 			final Name name = new Name("object", "key");
 			final Value created = surreal.create(rid, name);
 			assertEquals(created.get(Name.class), name);

--- a/src/test/java/com/surrealdb/ValueTypesTests.java
+++ b/src/test/java/com/surrealdb/ValueTypesTests.java
@@ -116,6 +116,24 @@ public class ValueTypesTests {
 	}
 
 	@Test
+	void recordIdArrayKeyAccessorsFromQuery() {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test").useDb("test");
+			Response r = surreal.query(
+					"CREATE myDoc:['myTenant', 'myUlid'] CONTENT { name: 'jules', tenant: 'myTenant' }");
+			Value v = r.take(0);
+			assertTrue(v.isArray());
+			RecordId recordId = v.getArray().get(0).getObject().get("id").getRecordId();
+			Id id = recordId.getId();
+			assertTrue(id.isArray());
+			Array idArray = id.getArray();
+			assertEquals(2, idArray.len());
+			assertEquals("myTenant", idArray.get(0).getString());
+			assertEquals("myUlid", idArray.get(1).getString());
+		}
+	}
+
+	@Test
 	void valueRangeFromQuery() {
 		try (Surreal surreal = new Surreal()) {
 			surreal.connect("memory").useNs("test").useDb("test");


### PR DESCRIPTION
## Summary

Fixes #140.

This fixes a JVM crash when accessing array- or object-backed `RecordId` keys through `RecordId.getId()`. The Java native declarations for `Id.getArray(...)` and `Id.getObject(...)` expected Java objects, while the JNI implementation returns raw native pointers (`jlong`). The JVM could then interpret a native pointer as an object reference, causing a SIGSEGV when calling methods like `len()` or `get(0)`.

## Changes

- Change `Id` native array/object accessors to return `long` native pointers.
- Wrap those pointers as `Array` / `Object` on the Java side, matching the existing `Value` accessor pattern.
- Add regression coverage for array-backed `RecordId` keys from query results.
- Add direct coverage for array- and object-backed `RecordId` key accessors.

## Testing

```bash
./gradlew test --tests com.surrealdb.ValueTypesTests.recordIdArrayKeyAccessorsFromQuery --tests com.surrealdb.TypeTests.testRecordIdWithArrayKey --tests com.surrealdb.TypeTests.testRecordIdWithObjectKey
git diff --check
```