### PR TITLE
Bump version to 2.0.2-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
 }
 
 group 'com.surrealdb'
-version '2.0.1'
+version '2.0.2-SNAPSHOT'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary

- Bump the Gradle project version from `2.0.1` to `2.0.2-SNAPSHOT` for post-release development.
- Keep README dependency examples on the published `2.0.1` release.

## Validation

- `git diff --check`
- `./gradlew -q help`