### PR TITLE
Add Java query binding overloads and transaction bindings

### DIFF
--- a/src/integrationTest/java/com/surrealdb/integration/IntegrationTest.java
+++ b/src/integrationTest/java/com/surrealdb/integration/IntegrationTest.java
@@ -15,9 +15,10 @@ import com.surrealdb.SurrealException;
 
 public class IntegrationTest {
 
-	// Skipped on Windows: SurrealDB is typically not started there in CI (setup-surreal is Linux/macOS).
+	// Skipped on Windows: SurrealDB is typically not started there in CI
+	// (setup-surreal is Linux/macOS).
 	@Test
-	@EnabledOnOs({ OS.LINUX, OS.MAC })
+	@EnabledOnOs({OS.LINUX, OS.MAC})
 	void surrealdb_websocket() {
 		// When SurrealDB is running at localhost:8000 (e.g. in CI), connect and verify.
 		try (Surreal surreal = new Surreal()) {
@@ -25,12 +26,14 @@ public class IntegrationTest {
 		}
 	}
 
-	// TODO: SurrealKV file backend triggers "Access is denied (os error 5)" on Windows CI
+	// TODO: SurrealKV file backend triggers "Access is denied (os error 5)" on
+	// Windows CI
 	// (both temp and project dir). Skip on Windows until root cause is fixed.
 	@Test
-	@EnabledOnOs({ OS.LINUX, OS.MAC })
+	@EnabledOnOs({OS.LINUX, OS.MAC})
 	void connectSurrealKV() throws SurrealException, IOException {
-		final Path dataDir = Paths.get(System.getProperty("user.dir"), "build", "surrealkv-it", "kv-" + System.nanoTime());
+		final Path dataDir = Paths.get(System.getProperty("user.dir"), "build", "surrealkv-it",
+				"kv-" + System.nanoTime());
 		Files.createDirectories(dataDir);
 		try (final Surreal surreal = new Surreal()) {
 			String path = dataDir.toAbsolutePath().toString().replace('\\', '/');

--- a/src/main/java/com/surrealdb/AlreadyExistsException.java
+++ b/src/main/java/com/surrealdb/AlreadyExistsException.java
@@ -3,8 +3,9 @@ package com.surrealdb;
 /**
  * Duplicate resource (table, record, namespace, database, session).
  *
- * <p>Details use the {@code {kind, details?}} format with variants defined
- * in {@link AlreadyExistsDetailKind}.
+ * <p>
+ * Details use the {@code {kind, details?}} format with variants defined in
+ * {@link AlreadyExistsDetailKind}.
  *
  * @see ErrorKind#ALREADY_EXISTS
  */

--- a/src/main/java/com/surrealdb/AuthDetailKind.java
+++ b/src/main/java/com/surrealdb/AuthDetailKind.java
@@ -3,7 +3,8 @@ package com.surrealdb;
 /**
  * Detail kind constants for authentication errors.
  *
- * <p>These appear nested inside {@link NotAllowedDetailKind#AUTH} details.
+ * <p>
+ * These appear nested inside {@link NotAllowedDetailKind#AUTH} details.
  *
  * @see NotAllowedException
  */

--- a/src/main/java/com/surrealdb/ConfigurationException.java
+++ b/src/main/java/com/surrealdb/ConfigurationException.java
@@ -3,8 +3,9 @@ package com.surrealdb;
 /**
  * Feature or configuration not supported (e.g. live queries, GraphQL).
  *
- * <p>Details use the {@code {kind, details?}} format with variants defined
- * in {@link ConfigurationDetailKind}.
+ * <p>
+ * Details use the {@code {kind, details?}} format with variants defined in
+ * {@link ConfigurationDetailKind}.
  *
  * @see ErrorKind#CONFIGURATION
  */

--- a/src/main/java/com/surrealdb/ErrorKind.java
+++ b/src/main/java/com/surrealdb/ErrorKind.java
@@ -4,25 +4,24 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Machine-readable error kind, aligned with the SurrealDB Rust SDK's {@code ErrorDetails} enum.
+ * Machine-readable error kind, aligned with the SurrealDB Rust SDK's
+ * {@code ErrorDetails} enum.
  *
- * <p>Returned by {@link ServerException#getKindEnum()}. Use this for type-safe matching instead
- * of {@link ServerException#getKind()} when the kind is known. For unknown (future) kinds,
- * {@link #UNKNOWN} is used and the raw string is available via {@link ServerException#getKind()}.
+ * <p>
+ * Returned by {@link ServerException#getKindEnum()}. Use this for type-safe
+ * matching instead of {@link ServerException#getKind()} when the kind is known.
+ * For unknown (future) kinds, {@link #UNKNOWN} is used and the raw string is
+ * available via {@link ServerException#getKind()}.
  */
 public enum ErrorKind {
 
-	VALIDATION("Validation"),
-	CONFIGURATION("Configuration"),
-	THROWN("Thrown"),
-	QUERY("Query"),
-	SERIALIZATION("Serialization"),
-	NOT_ALLOWED("NotAllowed"),
-	NOT_FOUND("NotFound"),
-	ALREADY_EXISTS("AlreadyExists"),
-	CONNECTION("Connection"),
-	INTERNAL("Internal"),
-	/** Unknown kind from a newer server; raw string is in {@link ServerException#getKind()}. */
+	VALIDATION("Validation"), CONFIGURATION("Configuration"), THROWN("Thrown"), QUERY("Query"), SERIALIZATION(
+			"Serialization"), NOT_ALLOWED("NotAllowed"), NOT_FOUND(
+					"NotFound"), ALREADY_EXISTS("AlreadyExists"), CONNECTION("Connection"), INTERNAL("Internal"),
+	/**
+	 * Unknown kind from a newer server; raw string is in
+	 * {@link ServerException#getKind()}.
+	 */
 	UNKNOWN(null);
 
 	private static final Map<String, ErrorKind> LOOKUP;
@@ -43,10 +42,11 @@ public enum ErrorKind {
 	}
 
 	/**
-	 * Resolves a kind string from the wire to an enum constant.
-	 * Unknown strings return {@link #UNKNOWN}.
+	 * Resolves a kind string from the wire to an enum constant. Unknown strings
+	 * return {@link #UNKNOWN}.
 	 *
-	 * @param kind the kind string (e.g. from the server)
+	 * @param kind
+	 *            the kind string (e.g. from the server)
 	 * @return the matching enum constant, or {@link #UNKNOWN}
 	 */
 	public static ErrorKind fromString(String kind) {

--- a/src/main/java/com/surrealdb/FileRef.java
+++ b/src/main/java/com/surrealdb/FileRef.java
@@ -3,9 +3,9 @@ package com.surrealdb;
 /**
  * Reference to a file stored in a SurrealDB bucket. Obtained from
  * {@link Value#getFile()} when {@link Value#isFile()} is true.
- * 
- * Valid only for the lifetime of the {@link Value} it was obtained from; do
- * not retain a reference after that Value is no longer in use.
+ *
+ * Valid only for the lifetime of the {@link Value} it was obtained from; do not
+ * retain a reference after that Value is no longer in use.
  */
 public class FileRef extends Native {
 

--- a/src/main/java/com/surrealdb/LiveStream.java
+++ b/src/main/java/com/surrealdb/LiveStream.java
@@ -6,24 +6,28 @@ import java.util.Optional;
  * Blocking iterator over live query notifications returned by
  * {@link Surreal#selectLive(String)}.
  *
- * <p>Typical usage:
+ * <p>
+ * Typical usage:
+ *
  * <pre>{@code
  * try (LiveStream stream = surreal.selectLive("person")) {
- *     while (true) {
- *         Optional<LiveNotification> n = stream.next();
- *         if (!n.isPresent()) break;   // stream closed
- *         process(n.get());
- *     }
+ * 	while (true) {
+ * 		Optional<LiveNotification> n = stream.next();
+ * 		if (!n.isPresent())
+ * 			break; // stream closed
+ * 		process(n.get());
+ * 	}
  * }
  * }</pre>
  *
- * <p><b>Thread safety:</b> {@link #next()} may be called from one thread while
+ * <p>
+ * <b>Thread safety:</b> {@link #next()} may be called from one thread while
  * {@link #close()} is called from another. The {@code close()} call will
- * unblock any thread currently waiting inside {@code next()}. The native
- * handle is declared {@code volatile} so that the zeroing performed by
- * {@code close()} is immediately visible to concurrent {@code next()} callers.
- * Concurrent calls to {@code next()} from multiple threads are serialized by
- * a mutex in the native layer.
+ * unblock any thread currently waiting inside {@code next()}. The native handle
+ * is declared {@code volatile} so that the zeroing performed by {@code close()}
+ * is immediately visible to concurrent {@code next()} callers. Concurrent calls
+ * to {@code next()} from multiple threads are serialized by a mutex in the
+ * native layer.
  */
 public class LiveStream implements AutoCloseable {
 
@@ -32,10 +36,10 @@ public class LiveStream implements AutoCloseable {
 	}
 
 	/**
-	 * Pointer to the native {@code LiveStreamChannel}. Zeroed by
-	 * {@link #close()} after the native resources have been released. Declared
-	 * {@code volatile} so that a {@code close()} on one thread is visible to a
-	 * concurrent {@code next()} on another thread.
+	 * Pointer to the native {@code LiveStreamChannel}. Zeroed by {@link #close()}
+	 * after the native resources have been released. Declared {@code volatile} so
+	 * that a {@code close()} on one thread is visible to a concurrent
+	 * {@code next()} on another thread.
 	 */
 	private volatile long handle;
 
@@ -46,10 +50,11 @@ public class LiveStream implements AutoCloseable {
 	/**
 	 * Blocks until the next notification is available, or the stream ends.
 	 *
-	 * <p>Returns {@link Optional#empty()} when the stream has been closed
-	 * (either explicitly via {@link #close()} or because the server ended the
-	 * live query). If the underlying live query encounters an error, a
-	 * {@link SurrealException} is thrown.
+	 * <p>
+	 * Returns {@link Optional#empty()} when the stream has been closed (either
+	 * explicitly via {@link #close()} or because the server ended the live query).
+	 * If the underlying live query encounters an error, a {@link SurrealException}
+	 * is thrown.
 	 *
 	 * @return the next notification, or empty if the stream has ended
 	 * @throws SurrealException
@@ -66,9 +71,10 @@ public class LiveStream implements AutoCloseable {
 	/**
 	 * Releases the live query and stops receiving notifications.
 	 *
-	 * <p>If another thread is blocked inside {@link #next()}, it will be
-	 * unblocked and will return {@link Optional#empty()}. This method is
-	 * idempotent: calling it more than once has no effect.
+	 * <p>
+	 * If another thread is blocked inside {@link #next()}, it will be unblocked and
+	 * will return {@link Optional#empty()}. This method is idempotent: calling it
+	 * more than once has no effect.
 	 */
 	@Override
 	public void close() {

--- a/src/main/java/com/surrealdb/Native.java
+++ b/src/main/java/com/surrealdb/Native.java
@@ -3,8 +3,8 @@ package com.surrealdb;
 /**
  * Base for types backed by a native pointer. Instances are only valid for the
  * lifetime of the native resource (e.g. the parent {@link Value} or connection
- * they were obtained from). Using an instance after the underlying resource
- * has been released may cause undefined behavior or native errors.
+ * they were obtained from). Using an instance after the underlying resource has
+ * been released may cause undefined behavior or native errors.
  */
 public abstract class Native {
 

--- a/src/main/java/com/surrealdb/NotAllowedException.java
+++ b/src/main/java/com/surrealdb/NotAllowedException.java
@@ -3,8 +3,9 @@ package com.surrealdb;
 /**
  * Permission denied, method not allowed, function or scripting blocked.
  *
- * <p>Details use the {@code {kind, details?}} format with variants defined
- * in {@link NotAllowedDetailKind}. Auth details further nest
+ * <p>
+ * Details use the {@code {kind, details?}} format with variants defined in
+ * {@link NotAllowedDetailKind}. Auth details further nest
  * {@link AuthDetailKind} variants.
  *
  * @see ErrorKind#NOT_ALLOWED
@@ -35,7 +36,8 @@ public class NotAllowedException extends ServerException {
 	 * @return whether the detail matches {@code Auth -> TokenExpired}
 	 */
 	public boolean isTokenExpired() {
-		return AuthDetailKind.TOKEN_EXPIRED.equals(extractAuthKind(getDetailValue(getDetails(), NotAllowedDetailKind.AUTH)));
+		return AuthDetailKind.TOKEN_EXPIRED
+				.equals(extractAuthKind(getDetailValue(getDetails(), NotAllowedDetailKind.AUTH)));
 	}
 
 	/**
@@ -44,7 +46,8 @@ public class NotAllowedException extends ServerException {
 	 * @return whether the detail matches {@code Auth -> InvalidAuth}
 	 */
 	public boolean isInvalidAuth() {
-		return AuthDetailKind.INVALID_AUTH.equals(extractAuthKind(getDetailValue(getDetails(), NotAllowedDetailKind.AUTH)));
+		return AuthDetailKind.INVALID_AUTH
+				.equals(extractAuthKind(getDetailValue(getDetails(), NotAllowedDetailKind.AUTH)));
 	}
 
 	/**

--- a/src/main/java/com/surrealdb/NotFoundException.java
+++ b/src/main/java/com/surrealdb/NotFoundException.java
@@ -3,8 +3,9 @@ package com.surrealdb;
 /**
  * Resource not found (table, record, namespace, database, RPC method, session).
  *
- * <p>Details use the {@code {kind, details?}} format with variants defined
- * in {@link NotFoundDetailKind}.
+ * <p>
+ * Details use the {@code {kind, details?}} format with variants defined in
+ * {@link NotFoundDetailKind}.
  *
  * @see ErrorKind#NOT_FOUND
  */

--- a/src/main/java/com/surrealdb/QueryException.java
+++ b/src/main/java/com/surrealdb/QueryException.java
@@ -5,8 +5,9 @@ import java.util.Map;
 /**
  * Query execution failure (not executed, timed out, cancelled).
  *
- * <p>Details use the {@code {kind, details?}} format with variants defined
- * in {@link QueryDetailKind}.
+ * <p>
+ * Details use the {@code {kind, details?}} format with variants defined in
+ * {@link QueryDetailKind}.
  *
  * @see ErrorKind#QUERY
  */
@@ -17,8 +18,8 @@ public class QueryException extends ServerException {
 	}
 
 	/**
-	 * Returns {@code true} when the query was not executed
-	 * (e.g. a previous statement in a multi-statement query failed).
+	 * Returns {@code true} when the query was not executed (e.g. a previous
+	 * statement in a multi-statement query failed).
 	 *
 	 * @return whether the detail kind is {@code NotExecuted}
 	 */
@@ -45,8 +46,8 @@ public class QueryException extends ServerException {
 	}
 
 	/**
-	 * Returns the timeout duration when the query timed out, as a map
-	 * containing {@code "secs"} and {@code "nanos"} keys.
+	 * Returns the timeout duration when the query timed out, as a map containing
+	 * {@code "secs"} and {@code "nanos"} keys.
 	 *
 	 * @return the timeout map, or {@code null}
 	 */

--- a/src/main/java/com/surrealdb/SerializationException.java
+++ b/src/main/java/com/surrealdb/SerializationException.java
@@ -3,8 +3,9 @@ package com.surrealdb;
 /**
  * Serialization or deserialization error.
  *
- * <p>Details use the {@code {kind, details?}} format with variants defined
- * in {@link SerializationDetailKind}.
+ * <p>
+ * Details use the {@code {kind, details?}} format with variants defined in
+ * {@link SerializationDetailKind}.
  *
  * @see ErrorKind#SERIALIZATION
  */
@@ -15,8 +16,8 @@ public class SerializationException extends ServerException {
 	}
 
 	/**
-	 * Returns {@code true} when this is specifically a deserialization error
-	 * (as opposed to serialization).
+	 * Returns {@code true} when this is specifically a deserialization error (as
+	 * opposed to serialization).
 	 *
 	 * @return whether the detail kind is {@code Deserialization}
 	 */

--- a/src/main/java/com/surrealdb/ServerException.java
+++ b/src/main/java/com/surrealdb/ServerException.java
@@ -8,26 +8,33 @@ import java.util.Map;
 /**
  * Base class for all exceptions originating from the SurrealDB server.
  *
- * <p>Carries structured error information: a machine-readable {@link #getKind() kind},
- * optional {@link #getDetails() details} using the {@code {kind, details?}} wire format,
- * and an optional typed {@link #getServerCause() cause} chain.
+ * <p>
+ * Carries structured error information: a machine-readable {@link #getKind()
+ * kind}, optional {@link #getDetails() details} using the {@code {kind,
+ * details?}} wire format, and an optional typed {@link #getServerCause() cause}
+ * chain.
  *
- * <p>Details follow the internally-tagged format where each detail object has a
+ * <p>
+ * Details follow the internally-tagged format where each detail object has a
  * {@code "kind"} field and an optional {@code "details"} field:
  * <ul>
- *   <li>Unit variant: {@code {"kind": "Parse"}}</li>
- *   <li>Newtype variant: {@code {"kind": "Auth", "details": {"kind": "TokenExpired"}}}</li>
- *   <li>Struct variant: {@code {"kind": "Table", "details": {"name": "users"}}}</li>
+ * <li>Unit variant: {@code {"kind": "Parse"}}</li>
+ * <li>Newtype variant: {@code {"kind": "Auth", "details": {"kind":
+ * "TokenExpired"}}}</li>
+ * <li>Struct variant: {@code {"kind": "Table", "details": {"name":
+ * "users"}}}</li>
  * </ul>
  *
- * <p>For backward compatibility with older servers, the legacy externally-tagged
- * format ({@code "Parse"}, {@code {"Auth": "TokenExpired"}},
- * {@code {"Table": {"name": "users"}}}) is also supported by all detail helpers.
+ * <p>
+ * For backward compatibility with older servers, the legacy externally-tagged
+ * format ({@code "Parse"}, {@code {"Auth": "TokenExpired"}}, {@code {"Table":
+ * {"name": "users"}}}) is also supported by all detail helpers.
  *
- * <p>Specific error kinds are represented by subclasses (e.g. {@link NotAllowedException},
- * {@link NotFoundException}). When the server returns an unknown kind, a plain
- * {@code ServerException} is used (not {@link InternalException}) to preserve forward
- * compatibility.
+ * <p>
+ * Specific error kinds are represented by subclasses (e.g.
+ * {@link NotAllowedException}, {@link NotFoundException}). When the server
+ * returns an unknown kind, a plain {@code ServerException} is used (not
+ * {@link InternalException}) to preserve forward compatibility.
  *
  * @see ErrorKind
  */
@@ -39,14 +46,19 @@ public class ServerException extends SurrealException {
 	private final ServerException serverCause;
 
 	/**
-	 * Constructs a {@code ServerException} from an {@link ErrorKind} and optional raw kind string.
-	 * Used by the JNI bridge when the native side passes the enum. When {@code kind} is
-	 * {@link ErrorKind#UNKNOWN}, {@code rawKindIfUnknown} must be the wire string.
+	 * Constructs a {@code ServerException} from an {@link ErrorKind} and optional
+	 * raw kind string. Used by the JNI bridge when the native side passes the enum.
+	 * When {@code kind} is {@link ErrorKind#UNKNOWN}, {@code rawKindIfUnknown} must
+	 * be the wire string.
 	 *
-	 * @param kind             the error kind enum (from the Rust SDK's ErrorDetails)
-	 * @param rawKindIfUnknown when {@code kind} is {@link ErrorKind#UNKNOWN}, the wire string; otherwise {@code null}
+	 * @param kind
+	 *            the error kind enum (from the Rust SDK's ErrorDetails)
+	 * @param rawKindIfUnknown
+	 *            when {@code kind} is {@link ErrorKind#UNKNOWN}, the wire string;
+	 *            otherwise {@code null}
 	 */
-	ServerException(ErrorKind kind, String rawKindIfUnknown, String message, java.lang.Object details, ServerException cause) {
+	ServerException(ErrorKind kind, String rawKindIfUnknown, String message, java.lang.Object details,
+			ServerException cause) {
 		super(message, cause);
 		this.kindEnum = kind;
 		this.rawKind = kind == ErrorKind.UNKNOWN ? rawKindIfUnknown : null;
@@ -55,8 +67,9 @@ public class ServerException extends SurrealException {
 	}
 
 	/**
-	 * Constructs a {@code ServerException} from a kind string (for subclasses and tests).
-	 * The kind is resolved to an {@link ErrorKind} via {@link ErrorKind#fromString(String)}.
+	 * Constructs a {@code ServerException} from a kind string (for subclasses and
+	 * tests). The kind is resolved to an {@link ErrorKind} via
+	 * {@link ErrorKind#fromString(String)}.
 	 */
 	ServerException(String kind, String message, java.lang.Object details, ServerException cause) {
 		super(message, cause);
@@ -68,9 +81,11 @@ public class ServerException extends SurrealException {
 
 	/**
 	 * Extracts the {@code "kind"} string from a {@code {kind, details?}} detail
-	 * object. Returns {@code null} if the details are not in internally-tagged format.
+	 * object. Returns {@code null} if the details are not in internally-tagged
+	 * format.
 	 *
-	 * @param details the details object (may be {@code null})
+	 * @param details
+	 *            the details object (may be {@code null})
 	 * @return the kind string, or {@code null}
 	 */
 	@SuppressWarnings("unchecked")
@@ -86,9 +101,11 @@ public class ServerException extends SurrealException {
 
 	/**
 	 * Extracts the {@code "details"} value from a {@code {kind, details?}} detail
-	 * object. Returns {@code null} if not present or not in internally-tagged format.
+	 * object. Returns {@code null} if not present or not in internally-tagged
+	 * format.
 	 *
-	 * @param details the details object (may be {@code null})
+	 * @param details
+	 *            the details object (may be {@code null})
 	 * @return the inner details value, or {@code null}
 	 */
 	@SuppressWarnings("unchecked")
@@ -100,16 +117,18 @@ public class ServerException extends SurrealException {
 	}
 
 	/**
-	 * Checks whether the details object matches a given variant key.
-	 * Supports both new and old formats:
+	 * Checks whether the details object matches a given variant key. Supports both
+	 * new and old formats:
 	 * <ul>
-	 *   <li>New: {@code {"kind": "Parse"}} -- checks if {@code kind} equals key</li>
-	 *   <li>Old: {@code "Parse"} -- checks if the string equals key</li>
-	 *   <li>Old: {@code {"Parse": ...}} -- checks if the map contains key</li>
+	 * <li>New: {@code {"kind": "Parse"}} -- checks if {@code kind} equals key</li>
+	 * <li>Old: {@code "Parse"} -- checks if the string equals key</li>
+	 * <li>Old: {@code {"Parse": ...}} -- checks if the map contains key</li>
 	 * </ul>
 	 *
-	 * @param details the details object (may be {@code null})
-	 * @param key     the key to look for
+	 * @param details
+	 *            the details object (may be {@code null})
+	 * @param key
+	 *            the key to look for
 	 * @return {@code true} if the key is present
 	 */
 	@SuppressWarnings("unchecked")
@@ -134,16 +153,19 @@ public class ServerException extends SurrealException {
 	}
 
 	/**
-	 * Extracts the inner value for a given variant key.
-	 * Supports both new and old formats:
+	 * Extracts the inner value for a given variant key. Supports both new and old
+	 * formats:
 	 * <ul>
-	 *   <li>New: if {@code kind} equals key, returns {@code details["details"]}</li>
-	 *   <li>Old: if details is a map, returns {@code details[key]}</li>
-	 *   <li>Old: if details is a string matching key, returns {@code null} (unit variant)</li>
+	 * <li>New: if {@code kind} equals key, returns {@code details["details"]}</li>
+	 * <li>Old: if details is a map, returns {@code details[key]}</li>
+	 * <li>Old: if details is a string matching key, returns {@code null} (unit
+	 * variant)</li>
 	 * </ul>
 	 *
-	 * @param details the details object (may be {@code null})
-	 * @param key     the key to extract
+	 * @param details
+	 *            the details object (may be {@code null})
+	 * @param key
+	 *            the key to extract
 	 * @return the value, or {@code null}
 	 */
 	@SuppressWarnings("unchecked")
@@ -171,16 +193,20 @@ public class ServerException extends SurrealException {
 	}
 
 	/**
-	 * Extracts a string field from a variant's inner details.
-	 * Supports both new and old formats.
+	 * Extracts a string field from a variant's inner details. Supports both new and
+	 * old formats.
 	 *
-	 * <p>New: {@code {"kind": "Table", "details": {"name": "users"}}}
-	 * <br>Old: {@code {"Table": {"name": "users"}}}
-	 * <br>Both: {@code detailField(details, "Table", "name")} returns {@code "users"}.
+	 * <p>
+	 * New: {@code {"kind": "Table", "details": {"name": "users"}}} <br>
+	 * Old: {@code {"Table": {"name": "users"}}} <br>
+	 * Both: {@code detailField(details, "Table", "name")} returns {@code "users"}.
 	 *
-	 * @param details the details object
-	 * @param key     the variant key
-	 * @param field   the field name inside the inner object
+	 * @param details
+	 *            the details object
+	 * @param key
+	 *            the variant key
+	 * @param field
+	 *            the field name inside the inner object
 	 * @return the string value, or {@code null}
 	 */
 	@SuppressWarnings("unchecked")
@@ -194,16 +220,19 @@ public class ServerException extends SurrealException {
 	}
 
 	/**
-	 * Extracts a string from the inner details of a newtype variant.
-	 * Supports both new and old formats:
+	 * Extracts a string from the inner details of a newtype variant. Supports both
+	 * new and old formats:
 	 * <ul>
-	 *   <li>New: {@code {"kind": "Auth", "details": {"kind": "TokenExpired"}}}
-	 *       -- returns {@code "TokenExpired"}</li>
-	 *   <li>Old: {@code {"Auth": "TokenExpired"}} -- returns {@code "TokenExpired"}</li>
+	 * <li>New: {@code {"kind": "Auth", "details": {"kind": "TokenExpired"}}} --
+	 * returns {@code "TokenExpired"}</li>
+	 * <li>Old: {@code {"Auth": "TokenExpired"}} -- returns
+	 * {@code "TokenExpired"}</li>
 	 * </ul>
 	 *
-	 * @param details the details object
-	 * @param key     the variant key
+	 * @param details
+	 *            the details object
+	 * @param key
+	 *            the variant key
 	 * @return the string value, or {@code null}
 	 */
 	static String getDetailString(java.lang.Object details, String key) {
@@ -224,7 +253,8 @@ public class ServerException extends SurrealException {
 	}
 
 	/**
-	 * @deprecated Use {@link #detailField(java.lang.Object, String, String)} instead.
+	 * @deprecated Use {@link #detailField(java.lang.Object, String, String)}
+	 *             instead.
 	 */
 	@SuppressWarnings("unchecked")
 	static String getNestedString(java.lang.Object details, String outerKey, String innerKey) {
@@ -232,7 +262,8 @@ public class ServerException extends SurrealException {
 	}
 
 	/**
-	 * @deprecated Use {@link #getDetailString(java.lang.Object, String)} with an equality check instead.
+	 * @deprecated Use {@link #getDetailString(java.lang.Object, String)} with an
+	 *             equality check instead.
 	 */
 	static boolean isNewtypeValue(java.lang.Object details, String outerKey, String value) {
 		return value.equals(getDetailString(details, outerKey));
@@ -242,13 +273,15 @@ public class ServerException extends SurrealException {
 	//
 	// SurrealDB v3 uses a recursive { "kind": "...", "details": ... } format
 	// for error details (internally-tagged). Older servers used serde's
-	// externally-tagged format ("Parse" / {"Auth": "TokenExpired"} / {"Table": {"name": "users"}}).
+	// externally-tagged format ("Parse" / {"Auth": "TokenExpired"} / {"Table":
+	// {"name": "users"}}).
 	//
 	// All helpers support both formats for backward compatibility.
 
 	/**
 	 * Returns the machine-readable error kind string (e.g. {@code "NotAllowed"}).
-	 * For unknown kinds this is the wire string; otherwise it matches {@link #getKindEnum()}{@code .getRaw()}.
+	 * For unknown kinds this is the wire string; otherwise it matches
+	 * {@link #getKindEnum()}{@code .getRaw()}.
 	 *
 	 * @return the error kind string, never {@code null}
 	 */
@@ -257,8 +290,9 @@ public class ServerException extends SurrealException {
 	}
 
 	/**
-	 * Returns the error kind as an enum for type-safe matching.
-	 * Unknown kinds from newer servers map to {@link ErrorKind#UNKNOWN}; the raw string is in {@link #getKind()}.
+	 * Returns the error kind as an enum for type-safe matching. Unknown kinds from
+	 * newer servers map to {@link ErrorKind#UNKNOWN}; the raw string is in
+	 * {@link #getKind()}.
 	 *
 	 * @return the error kind enum, never {@code null}
 	 */
@@ -269,16 +303,20 @@ public class ServerException extends SurrealException {
 	/**
 	 * Returns the optional structured details for this error.
 	 *
-	 * <p>Details use the {@code {kind, details?}} wire format. The value is either:
+	 * <p>
+	 * Details use the {@code {kind, details?}} wire format. The value is either:
 	 * <ul>
-	 *   <li>{@code null} -- no details</li>
-	 *   <li>a {@code Map<String, Object>} with a {@code "kind"} key and optional
-	 *       {@code "details"} key (new internally-tagged format)</li>
-	 *   <li>a {@link String} -- a unit variant in the legacy format (e.g. {@code "Parse"})</li>
-	 *   <li>a {@code Map<String, Object>} without {@code "kind"} -- legacy externally-tagged format</li>
+	 * <li>{@code null} -- no details</li>
+	 * <li>a {@code Map<String, Object>} with a {@code "kind"} key and optional
+	 * {@code "details"} key (new internally-tagged format)</li>
+	 * <li>a {@link String} -- a unit variant in the legacy format (e.g.
+	 * {@code "Parse"})</li>
+	 * <li>a {@code Map<String, Object>} without {@code "kind"} -- legacy
+	 * externally-tagged format</li>
 	 * </ul>
 	 *
-	 * <p>Prefer the typed convenience getters on subclasses (e.g.
+	 * <p>
+	 * Prefer the typed convenience getters on subclasses (e.g.
 	 * {@link NotFoundException#getTableName()}) over inspecting details directly.
 	 *
 	 * @return the details object, or {@code null}
@@ -290,7 +328,8 @@ public class ServerException extends SurrealException {
 	/**
 	 * Returns the typed server-side cause of this error, if any.
 	 *
-	 * <p>This is equivalent to calling {@link #getCause()} and casting to
+	 * <p>
+	 * This is equivalent to calling {@link #getCause()} and casting to
 	 * {@code ServerException}, but avoids the cast.
 	 *
 	 * @return the server cause, or {@code null}
@@ -303,7 +342,8 @@ public class ServerException extends SurrealException {
 	 * Checks whether this error or any error in its cause chain has the given
 	 * {@link ErrorKind kind}.
 	 *
-	 * @param kind the kind to look for
+	 * @param kind
+	 *            the kind to look for
 	 * @return {@code true} if any error in the chain matches
 	 */
 	public boolean hasKind(String kind) {
@@ -311,7 +351,8 @@ public class ServerException extends SurrealException {
 	}
 
 	/**
-	 * Checks whether this error or any error in its cause chain has the given {@link ErrorKind}.
+	 * Checks whether this error or any error in its cause chain has the given
+	 * {@link ErrorKind}.
 	 */
 	public boolean hasKind(ErrorKind kind) {
 		return findCause(kind) != null;
@@ -320,10 +361,11 @@ public class ServerException extends SurrealException {
 	// ---- Legacy helpers (delegate to new ones for backward source compat) ----
 
 	/**
-	 * Finds the first error in the cause chain (including this error) that has
-	 * the given {@link ErrorKind kind}.
+	 * Finds the first error in the cause chain (including this error) that has the
+	 * given {@link ErrorKind kind}.
 	 *
-	 * @param kind the kind to look for
+	 * @param kind
+	 *            the kind to look for
 	 * @return the matching {@code ServerException}, or {@code null}
 	 */
 	public ServerException findCause(String kind) {
@@ -338,7 +380,8 @@ public class ServerException extends SurrealException {
 	}
 
 	/**
-	 * Finds the first error in the cause chain (including this error) that has the given {@link ErrorKind}.
+	 * Finds the first error in the cause chain (including this error) that has the
+	 * given {@link ErrorKind}.
 	 */
 	public ServerException findCause(ErrorKind kind) {
 		ServerException current = this;

--- a/src/main/java/com/surrealdb/Surreal.java
+++ b/src/main/java/com/surrealdb/Surreal.java
@@ -507,8 +507,13 @@ public class Surreal extends Native implements AutoCloseable {
 	 * @return a Response object containing the results of the query
 	 */
 	public Response query(String sql, Map<String, ?> params) {
-		final ValueBuilder.BoundParams p = ValueBuilder.packParams(params);
-		return new Response(queryWithBindings(getPtr(), sql, p.keys, p.values));
+		final Map<String, ValueMut> valueMuts = ValueBuilder.convertParams(params);
+		final String[] keys = valueMuts.keySet().toArray(new String[0]);
+		final long[] values = new long[keys.length];
+		for (int i = 0; i < keys.length; i++) {
+			values[i] = valueMuts.get(keys[i]).getPtr();
+		}
+		return new Response(queryWithBindings(getPtr(), sql, keys, values));
 	}
 
 	/**

--- a/src/main/java/com/surrealdb/Surreal.java
+++ b/src/main/java/com/surrealdb/Surreal.java
@@ -81,7 +81,7 @@ public class Surreal extends Native implements AutoCloseable {
 
 	private static native long query(long ptr, String sql);
 
-	private static native long queryBind(long ptr, String sql, String[] paramsKey, long[] valuePtrs);
+	private static native long queryWithBindings(long ptr, String sql, String[] paramsKey, long[] valuePtrs);
 
 	private static native long createRecordIdValue(long ptr, long recordIdPtr, long valuePtr);
 
@@ -504,7 +504,7 @@ public class Surreal extends Native implements AutoCloseable {
 	 *            a map containing parameter values to be bound to the SQL query
 	 * @return a Response object containing the results of the query
 	 */
-	public Response queryBind(String sql, Map<String, ?> params) {
+	public Response query(String sql, Map<String, ?> params) {
 		Map<String, ValueMut> valueMutMap = params.entrySet().stream()
 				.collect(Collectors.toMap(Map.Entry::getKey, entry -> ValueBuilder.convert(entry.getValue())));
 		String[] keys = valueMutMap.keySet().toArray(new String[0]);
@@ -512,7 +512,28 @@ public class Surreal extends Native implements AutoCloseable {
 		for (int i = 0; i < keys.length; i++) {
 			values[i] = valueMutMap.get(keys[i]).getPtr();
 		}
-		return new Response(queryBind(getPtr(), sql, keys, values));
+		return new Response(queryWithBindings(getPtr(), sql, keys, values));
+	}
+
+	/**
+	 * Executes a parameterized SurrealQL query on the database.
+	 * <p>
+	 * For more details, check the
+	 * <a href="https://surrealdb.com/docs/surrealql">SurrealQL documentation</a>.
+	 * <p>
+	 *
+	 * @param sql
+	 *            the SurrealQL query to be executed
+	 * @param params
+	 *            a map containing parameter values to be bound to the SQL query
+	 * @return a Response object containing the results of the query
+	 * @deprecated Since 2.0.2. Use {@link #query(String, Map)} instead. Java
+	 *             prefers method overloading over suffixing method names. This
+	 *             method is intended for removal in 3.0.0.
+	 */
+	@Deprecated
+	public Response queryBind(String sql, Map<String, ?> params) {
+		return query(sql, params);
 	}
 
 	/**

--- a/src/main/java/com/surrealdb/Surreal.java
+++ b/src/main/java/com/surrealdb/Surreal.java
@@ -507,14 +507,8 @@ public class Surreal extends Native implements AutoCloseable {
 	 * @return a Response object containing the results of the query
 	 */
 	public Response query(String sql, Map<String, ?> params) {
-		Map<String, ValueMut> valueMutMap = params.entrySet().stream()
-				.collect(Collectors.toMap(Map.Entry::getKey, entry -> ValueBuilder.convert(entry.getValue())));
-		String[] keys = valueMutMap.keySet().toArray(new String[0]);
-		long[] values = new long[keys.length];
-		for (int i = 0; i < keys.length; i++) {
-			values[i] = valueMutMap.get(keys[i]).getPtr();
-		}
-		return new Response(queryWithBindings(getPtr(), sql, keys, values));
+		final ValueBuilder.BoundParams p = ValueBuilder.packParams(params);
+		return new Response(queryWithBindings(getPtr(), sql, p.keys, p.values));
 	}
 
 	/**

--- a/src/main/java/com/surrealdb/Surreal.java
+++ b/src/main/java/com/surrealdb/Surreal.java
@@ -268,12 +268,14 @@ public class Surreal extends Native implements AutoCloseable {
 	 * Starts a live query on the given table and returns a blocking stream of
 	 * notifications (CREATE, UPDATE, DELETE).
 	 *
-	 * <p>This method blocks until the live query subscription is fully
-	 * established on the server. If the subscription fails (e.g. the table does
-	 * not exist), a {@link SurrealException} is thrown immediately rather than
-	 * being deferred to the first {@link LiveStream#next()} call.
+	 * <p>
+	 * This method blocks until the live query subscription is fully established on
+	 * the server. If the subscription fails (e.g. the table does not exist), a
+	 * {@link SurrealException} is thrown immediately rather than being deferred to
+	 * the first {@link LiveStream#next()} call.
 	 *
-	 * <p>Call {@link LiveStream#next()} in a loop to receive notifications and
+	 * <p>
+	 * Call {@link LiveStream#next()} in a loop to receive notifications and
 	 * {@link LiveStream#close()} when done. The returned stream implements
 	 * {@link AutoCloseable} for use in try-with-resources.
 	 *
@@ -282,8 +284,8 @@ public class Surreal extends Native implements AutoCloseable {
 	 * @return a LiveStream; the caller must call {@link LiveStream#close()} when
 	 *         done
 	 * @throws SurrealException
-	 *             if live queries are not supported, the table does not exist,
-	 *             or the subscription fails
+	 *             if live queries are not supported, the table does not exist, or
+	 *             the subscription fails
 	 */
 	public LiveStream selectLive(String table) {
 		return new LiveStream(selectLive(getPtr(), table));

--- a/src/main/java/com/surrealdb/Transaction.java
+++ b/src/main/java/com/surrealdb/Transaction.java
@@ -2,7 +2,6 @@ package com.surrealdb;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Client-side transaction. Use {@link Surreal#beginTransaction()} to start a
@@ -72,14 +71,8 @@ public class Transaction extends Native {
 	 * @return the query response
 	 */
 	public Response query(String sql, Map<String, ?> params) {
-		Map<String, ValueMut> valueMutMap = params.entrySet().stream()
-				.collect(Collectors.toMap(Map.Entry::getKey, entry -> ValueBuilder.convert(entry.getValue())));
-		String[] keys = valueMutMap.keySet().toArray(new String[0]);
-		long[] values = new long[keys.length];
-		for (int i = 0; i < keys.length; i++) {
-			values[i] = valueMutMap.get(keys[i]).getPtr();
-		}
-		return new Response(queryWithBindings(getPtr(), sql, keys, values));
+		final ValueBuilder.BoundParams p = ValueBuilder.packParams(params);
+		return new Response(queryWithBindings(getPtr(), sql, p.keys, p.values));
 	}
 
 	@Override

--- a/src/main/java/com/surrealdb/Transaction.java
+++ b/src/main/java/com/surrealdb/Transaction.java
@@ -71,8 +71,13 @@ public class Transaction extends Native {
 	 * @return the query response
 	 */
 	public Response query(String sql, Map<String, ?> params) {
-		final ValueBuilder.BoundParams p = ValueBuilder.packParams(params);
-		return new Response(queryWithBindings(getPtr(), sql, p.keys, p.values));
+		final Map<String, ValueMut> valueMuts = ValueBuilder.convertParams(params);
+		final String[] keys = valueMuts.keySet().toArray(new String[0]);
+		final long[] values = new long[keys.length];
+		for (int i = 0; i < keys.length; i++) {
+			values[i] = valueMuts.get(keys[i]).getPtr();
+		}
+		return new Response(queryWithBindings(getPtr(), sql, keys, values));
 	}
 
 	@Override

--- a/src/main/java/com/surrealdb/Transaction.java
+++ b/src/main/java/com/surrealdb/Transaction.java
@@ -1,6 +1,8 @@
 package com.surrealdb;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Client-side transaction. Use {@link Surreal#beginTransaction()} to start a
@@ -20,6 +22,8 @@ public class Transaction extends Native {
 	private static native boolean cancel(long ptr);
 
 	private static native long query(long ptr, String sql);
+
+	private static native long queryWithBindings(long ptr, String sql, String[] paramsKey, long[] valuePtrs);
 
 	/**
 	 * Commits the transaction. After this call, the transaction is completed and
@@ -56,6 +60,26 @@ public class Transaction extends Native {
 	 */
 	public Response query(String sql) {
 		return new Response(query(getPtr(), sql));
+	}
+
+	/**
+	 * Runs a parameterized SurrealQL query within this transaction.
+	 *
+	 * @param sql
+	 *            the SurrealQL query
+	 * @param params
+	 *            a map containing parameter values to be bound to the SQL query
+	 * @return the query response
+	 */
+	public Response query(String sql, Map<String, ?> params) {
+		Map<String, ValueMut> valueMutMap = params.entrySet().stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, entry -> ValueBuilder.convert(entry.getValue())));
+		String[] keys = valueMutMap.keySet().toArray(new String[0]);
+		long[] values = new long[keys.length];
+		for (int i = 0; i < keys.length; i++) {
+			values[i] = valueMutMap.get(keys[i]).getPtr();
+		}
+		return new Response(queryWithBindings(getPtr(), sql, keys, values));
 	}
 
 	@Override

--- a/src/main/java/com/surrealdb/ValidationException.java
+++ b/src/main/java/com/surrealdb/ValidationException.java
@@ -3,8 +3,9 @@ package com.surrealdb;
 /**
  * Invalid input: parse error, invalid request or parameters, bad input values.
  *
- * <p>Details use the {@code {kind, details?}} format with variants defined
- * in {@link ValidationDetailKind}.
+ * <p>
+ * Details use the {@code {kind, details?}} format with variants defined in
+ * {@link ValidationDetailKind}.
  *
  * @see ErrorKind#VALIDATION
  */
@@ -24,8 +25,8 @@ public class ValidationException extends ServerException {
 	}
 
 	/**
-	 * Returns the invalid parameter name, if this is an
-	 * {@code InvalidParameter} error.
+	 * Returns the invalid parameter name, if this is an {@code InvalidParameter}
+	 * error.
 	 *
 	 * @return the parameter name, or {@code null}
 	 */

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -128,4 +128,25 @@ class ValueBuilder {
 		}
 	}
 
+	static BoundParams packParams(final Map<String, ?> params) {
+		final Map<String, ValueMut> valueMutMap = params.entrySet().stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, entry -> convert(entry.getValue())));
+		final String[] keys = valueMutMap.keySet().toArray(new String[0]);
+		final long[] values = new long[keys.length];
+		for (int i = 0; i < keys.length; i++) {
+			values[i] = valueMutMap.get(keys[i]).getPtr();
+		}
+		return new BoundParams(keys, values);
+	}
+
+	static final class BoundParams {
+		final String[] keys;
+		final long[] values;
+
+		BoundParams(final String[] keys, final long[] values) {
+			this.keys = keys;
+			this.values = values;
+		}
+	}
+
 }

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -128,25 +128,9 @@ class ValueBuilder {
 		}
 	}
 
-	static BoundParams packParams(final Map<String, ?> params) {
-		final Map<String, ValueMut> valueMutMap = params.entrySet().stream()
+	static Map<String, ValueMut> convertParams(final Map<String, ?> params) {
+		return params.entrySet().stream()
 				.collect(Collectors.toMap(Map.Entry::getKey, entry -> convert(entry.getValue())));
-		final String[] keys = valueMutMap.keySet().toArray(new String[0]);
-		final long[] values = new long[keys.length];
-		for (int i = 0; i < keys.length; i++) {
-			values[i] = valueMutMap.get(keys[i]).getPtr();
-		}
-		return new BoundParams(keys, values);
-	}
-
-	static final class BoundParams {
-		final String[] keys;
-		final long[] values;
-
-		BoundParams(final String[] keys, final long[] values) {
-			this.keys = keys;
-			this.values = values;
-		}
 	}
 
 }

--- a/src/main/java/com/surrealdb/signin/BearerCredential.java
+++ b/src/main/java/com/surrealdb/signin/BearerCredential.java
@@ -15,8 +15,7 @@ public class BearerCredential implements Credential {
 	 * Creates a bearer credential with the given access token.
 	 *
 	 * @param token
-	 * the access token (JWT) to use for authentication; must not be
-	 * null
+	 *            the access token (JWT) to use for authentication; must not be null
 	 */
 	public BearerCredential(String token) {
 		this.token = Objects.requireNonNull(token, "token");

--- a/src/main/rust/macros.rs
+++ b/src/main/rust/macros.rs
@@ -387,3 +387,20 @@ macro_rules! convert_up_type {
         }
     };
 }
+
+/// Builds a BTreeMap<String, Value> from JNI parameter-key and value-pointer
+/// arrays. Used by the queryWithBindings JNI entrypoints on both Surreal and
+/// Transaction.
+#[macro_export]
+macro_rules! build_params_map {
+    ($env:expr, $keys:expr, $values:expr, $default_fn:expr) => {{
+        let keys = $crate::get_rust_string_array!($env, $keys, $default_fn);
+        let value_ptrs = $crate::get_long_array!($env, &$values, $default_fn);
+        let mut params_map = std::collections::BTreeMap::<String, surrealdb::types::Value>::new();
+        for (key, value_ptr) in keys.into_iter().zip(value_ptrs) {
+            let value = $crate::get_value_mut_instance!($env, value_ptr, $default_fn);
+            params_map.insert(key, value.clone());
+        }
+        params_map
+    }};
+}

--- a/src/main/rust/surreal.rs
+++ b/src/main/rust/surreal.rs
@@ -429,7 +429,7 @@ pub extern "system" fn Java_com_surrealdb_Surreal_query<'local>(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_com_surrealdb_Surreal_queryBind<'local>(
+pub extern "system" fn Java_com_surrealdb_Surreal_queryWithBindings<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
     ptr: jlong,

--- a/src/main/rust/surreal.rs
+++ b/src/main/rust/surreal.rs
@@ -5,10 +5,11 @@ use std::sync::Arc;
 
 use crate::error::SurrealError;
 use crate::{
-    check_query_result, convert_up_type, get_long_array, get_rust_string, get_rust_string_array,
-    get_surreal_ref, get_value_instance, get_value_mut_instance, new_jlong_array, new_string,
-    release_instance, return_unexpected_result, return_value_array_first, return_value_array_iter,
-    return_value_array_iter_sync, take_one_result, JniTypes, TOKIO_RUNTIME,
+    build_params_map, check_query_result, convert_up_type, get_long_array, get_rust_string,
+    get_rust_string_array, get_surreal_ref, get_value_instance, get_value_mut_instance,
+    new_jlong_array, new_string, release_instance, return_unexpected_result,
+    return_value_array_first, return_value_array_iter, return_value_array_iter_sync,
+    take_one_result, JniTypes, TOKIO_RUNTIME,
 };
 use futures::StreamExt;
 use jni::objects::{JClass, JLongArray, JObject, JObjectArray, JString, JValue};
@@ -437,21 +438,11 @@ pub extern "system" fn Java_com_surrealdb_Surreal_queryWithBindings<'local>(
     params_keys: JObjectArray<'local>,
     params_values: JLongArray<'local>,
 ) -> jlong {
-    // Retrieve the Surreal instance
     let surreal = get_surreal_ref!(&mut env, ptr, || 0);
-    // Retrieve the query
     let query = get_rust_string!(&mut env, &query, || 0);
-    let keys = get_rust_string_array!(&mut env, params_keys, || 0);
-    let value_ptrs = get_long_array!(&mut env, &params_values, || 0);
-    let mut params_map = BTreeMap::<String, Value>::new();
-    for (key, value_ptr) in keys.into_iter().zip(value_ptrs) {
-        let value = get_value_mut_instance!(&mut env, value_ptr, || 0);
-        params_map.insert(key, value.clone());
-    }
-
+    let params_map = build_params_map!(&mut env, params_keys, params_values, || 0);
     let res = surrealdb_query::<Value>(surreal, &query, Some(params_map));
     let res = check_query_result!(&mut env, res, || 0);
-    // Build a response instance
     JniTypes::new_response(Arc::new(Mutex::new(res)))
 }
 

--- a/src/main/rust/transaction.rs
+++ b/src/main/rust/transaction.rs
@@ -1,18 +1,21 @@
 //! JNI bindings for client-side Transaction (begin/commit/cancel/query).
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::error::SurrealError;
 use crate::{
-    check_query_result, get_rust_string, get_transaction_ref, release_instance, take_instance,
-    JniTypes, TOKIO_RUNTIME,
+    check_query_result, get_long_array, get_rust_string, get_rust_string_array,
+    get_transaction_ref, get_value_mut_instance, release_instance, take_instance, JniTypes,
+    TOKIO_RUNTIME,
 };
-use jni::objects::{JClass, JString};
+use jni::objects::{JClass, JLongArray, JObjectArray, JString};
 use jni::sys::{jboolean, jlong};
 use jni::JNIEnv;
 use parking_lot::Mutex;
 use surrealdb::engine::any::Any;
 use surrealdb::method::Transaction;
+use surrealdb::types::Value;
 
 #[no_mangle]
 pub extern "system" fn Java_com_surrealdb_Transaction_nativeDeleteInstance<'local>(
@@ -65,8 +68,32 @@ pub extern "system" fn Java_com_surrealdb_Transaction_query<'local>(
     query: JString<'local>,
 ) -> jlong {
     let txn = get_transaction_ref!(&mut env, ptr, || 0);
-    let query_str = get_rust_string!(&mut env, query, || 0);
-    let res = TOKIO_RUNTIME.block_on(async { txn.query(&query_str).await });
+    let query = get_rust_string!(&mut env, query, || 0);
+    let res = TOKIO_RUNTIME.block_on(async { txn.query(&query).await });
+    let res = check_query_result!(&mut env, res, || 0);
+    JniTypes::new_response(Arc::new(Mutex::new(res)))
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Transaction_queryWithBindings<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    ptr: jlong,
+    query: JString<'local>,
+    params_keys: JObjectArray<'local>,
+    params_values: JLongArray<'local>,
+) -> jlong {
+    let txn = get_transaction_ref!(&mut env, ptr, || 0);
+    let query = get_rust_string!(&mut env, query, || 0);
+    let keys = get_rust_string_array!(&mut env, params_keys, || 0);
+    let value_ptrs = get_long_array!(&mut env, &params_values, || 0);
+    let mut params_map = BTreeMap::<String, Value>::new();
+    for (key, value_ptr) in keys.into_iter().zip(value_ptrs) {
+        let value = get_value_mut_instance!(&mut env, value_ptr, || 0);
+        params_map.insert(key, value.clone());
+    }
+
+    let res = TOKIO_RUNTIME.block_on(async { txn.query(&query).bind(params_map).await });
     let res = check_query_result!(&mut env, res, || 0);
     JniTypes::new_response(Arc::new(Mutex::new(res)))
 }

--- a/src/main/rust/transaction.rs
+++ b/src/main/rust/transaction.rs
@@ -1,13 +1,11 @@
 //! JNI bindings for client-side Transaction (begin/commit/cancel/query).
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::error::SurrealError;
 use crate::{
-    check_query_result, get_long_array, get_rust_string, get_rust_string_array,
-    get_transaction_ref, get_value_mut_instance, release_instance, take_instance, JniTypes,
-    TOKIO_RUNTIME,
+    build_params_map, check_query_result, get_rust_string, get_transaction_ref, release_instance,
+    take_instance, JniTypes, TOKIO_RUNTIME,
 };
 use jni::objects::{JClass, JLongArray, JObjectArray, JString};
 use jni::sys::{jboolean, jlong};
@@ -15,7 +13,6 @@ use jni::JNIEnv;
 use parking_lot::Mutex;
 use surrealdb::engine::any::Any;
 use surrealdb::method::Transaction;
-use surrealdb::types::Value;
 
 #[no_mangle]
 pub extern "system" fn Java_com_surrealdb_Transaction_nativeDeleteInstance<'local>(
@@ -85,14 +82,7 @@ pub extern "system" fn Java_com_surrealdb_Transaction_queryWithBindings<'local>(
 ) -> jlong {
     let txn = get_transaction_ref!(&mut env, ptr, || 0);
     let query = get_rust_string!(&mut env, query, || 0);
-    let keys = get_rust_string_array!(&mut env, params_keys, || 0);
-    let value_ptrs = get_long_array!(&mut env, &params_values, || 0);
-    let mut params_map = BTreeMap::<String, Value>::new();
-    for (key, value_ptr) in keys.into_iter().zip(value_ptrs) {
-        let value = get_value_mut_instance!(&mut env, value_ptr, || 0);
-        params_map.insert(key, value.clone());
-    }
-
+    let params_map = build_params_map!(&mut env, params_keys, params_values, || 0);
     let res = TOKIO_RUNTIME.block_on(async { txn.query(&query).bind(params_map).await });
     let res = check_query_result!(&mut env, res, || 0);
     JniTypes::new_response(Arc::new(Mutex::new(res)))

--- a/src/test/java/com/surrealdb/ErrorIntegrationTests.java
+++ b/src/test/java/com/surrealdb/ErrorIntegrationTests.java
@@ -8,8 +8,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
 
 /**
- * Integration tests that verify structured error information survives the
- * JNI bridge round-trip. These tests trigger real errors from the embedded
+ * Integration tests that verify structured error information survives the JNI
+ * bridge round-trip. These tests trigger real errors from the embedded
  * SurrealDB engine and check the exception type and properties.
  */
 public class ErrorIntegrationTests {
@@ -43,8 +43,7 @@ public class ErrorIntegrationTests {
 			} catch (SurrealException e) {
 				assertNotNull(e.getMessage());
 				// Should be a ServerException (not just a plain SurrealException)
-				assertTrue(e instanceof ServerException,
-						"Expected ServerException but got " + e.getClass().getName());
+				assertTrue(e instanceof ServerException, "Expected ServerException but got " + e.getClass().getName());
 			}
 		}
 	}

--- a/src/test/java/com/surrealdb/ErrorTests.java
+++ b/src/test/java/com/surrealdb/ErrorTests.java
@@ -13,11 +13,12 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for the structured error handling classes.
- * These tests construct exceptions directly (no JNI) to verify the Java-side
- * class hierarchy, detail parsing, convenience getters, and cause chain traversal.
+ * Unit tests for the structured error handling classes. These tests construct
+ * exceptions directly (no JNI) to verify the Java-side class hierarchy, detail
+ * parsing, convenience getters, and cause chain traversal.
  *
- * <p>Each accessor is tested with both the new internally-tagged format
+ * <p>
+ * Each accessor is tested with both the new internally-tagged format
  * ({@code {"kind": "...", "details": ...}}) and the legacy externally-tagged
  * format ({@code "..." / {"...": ...}}).
  */
@@ -38,7 +39,9 @@ public class ErrorTests {
 		return m;
 	}
 
-	/** New format: newtype variant {@code {"kind": "X", "details": {"kind": "Y"}}}. */
+	/**
+	 * New format: newtype variant {@code {"kind": "X", "details": {"kind": "Y"}}}.
+	 */
 	private static Map<String, java.lang.Object> nfNested(String kind, String innerKind) {
 		Map<String, java.lang.Object> inner = new LinkedHashMap<>();
 		inner.put("kind", innerKind);
@@ -228,7 +231,8 @@ public class ErrorTests {
 
 	@Test
 	void hierarchyServerException() {
-		ServerException e = new ServerException(ErrorKind.CONNECTION, null, "conn error", (java.lang.Object) null, null);
+		ServerException e = new ServerException(ErrorKind.CONNECTION, null, "conn error", (java.lang.Object) null,
+				null);
 		assertTrue(e instanceof SurrealException);
 		assertFalse(e instanceof InternalException);
 		assertEquals(ErrorKind.CONNECTION, e.getKindEnum());
@@ -256,7 +260,8 @@ public class ErrorTests {
 		}
 	}
 
-	// Detail structure is built on the native (Rust) side and passed as Object (Map/List/String/Number).
+	// Detail structure is built on the native (Rust) side and passed as Object
+	// (Map/List/String/Number).
 	// The tests below verify the Java detail helpers work with that structure.
 
 	// ---- detailKind / detailInner ----
@@ -960,7 +965,7 @@ public class ErrorTests {
 	@Test
 	void doubleWrappedDetailsManuallyUnwrapped() {
 		// After the Rust bridge unwraps, Java receives:
-		//   {"kind": "Record", "details": {"id": "person:dup"}}
+		// {"kind": "Record", "details": {"id": "person:dup"}}
 		Map<String, java.lang.Object> inner = new LinkedHashMap<>();
 		inner.put("id", "person:dup");
 		Map<String, java.lang.Object> details = new LinkedHashMap<>();

--- a/src/test/java/com/surrealdb/ExportImportTests.java
+++ b/src/test/java/com/surrealdb/ExportImportTests.java
@@ -10,7 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link Surreal#exportSql(String)} and {@link Surreal#importSql(String)}.
+ * Tests for {@link Surreal#exportSql(String)} and
+ * {@link Surreal#importSql(String)}.
  */
 public class ExportImportTests {
 

--- a/src/test/java/com/surrealdb/LiveQueryTests.java
+++ b/src/test/java/com/surrealdb/LiveQueryTests.java
@@ -82,8 +82,8 @@ public class LiveQueryTests {
 	}
 
 	/**
-	 * Reproduces issue #138: start a live query, block on next(), then CREATE
-	 * a record — the notification must arrive. The bug report claims it never does.
+	 * Reproduces issue #138: start a live query, block on next(), then CREATE a
+	 * record — the notification must arrive. The bug report claims it never does.
 	 */
 	@Test
 	void liveStreamReceivesCreateNotification() throws Exception {
@@ -108,31 +108,27 @@ public class LiveQueryTests {
 				consumer.setDaemon(true);
 				consumer.start();
 
-				assertTrue(consuming.await(2, TimeUnit.SECONDS),
-						"Consumer thread did not start in time");
+				assertTrue(consuming.await(2, TimeUnit.SECONDS), "Consumer thread did not start in time");
 				Thread.sleep(500);
 
 				surreal.create(new RecordId("person", 1), Helpers.tobie);
 
 				consumer.join(5000);
-				assertFalse(consumer.isAlive(),
-						"Consumer thread still blocked — next() never returned");
+				assertFalse(consumer.isAlive(), "Consumer thread still blocked — next() never returned");
 			}
 
 			if (error.get() != null) {
 				fail("next() threw an exception: " + error.get());
 			}
-			assertNotNull(received.get(),
-					"No notification received after CREATE");
+			assertNotNull(received.get(), "No notification received after CREATE");
 			assertEquals("CREATE", received.get().getAction().toUpperCase());
-			assertNotNull(received.get().getValue(),
-					"Notification value should contain the created record");
+			assertNotNull(received.get().getValue(), "Notification value should contain the created record");
 		}
 	}
 
 	/**
-	 * Reproduces issue #138 variant: live query + UPDATE should deliver
-	 * a notification to next().
+	 * Reproduces issue #138 variant: live query + UPDATE should deliver a
+	 * notification to next().
 	 */
 	@Test
 	void liveStreamReceivesUpdateNotification() throws Exception {
@@ -159,19 +155,17 @@ public class LiveQueryTests {
 				surreal.update(id, UpType.MERGE, Helpers.jaime);
 
 				consumer.join(5000);
-				assertFalse(consumer.isAlive(),
-						"Consumer thread still blocked — next() never returned after UPDATE");
+				assertFalse(consumer.isAlive(), "Consumer thread still blocked — next() never returned after UPDATE");
 			}
 
-			assertNotNull(received.get(),
-					"No notification received after UPDATE");
+			assertNotNull(received.get(), "No notification received after UPDATE");
 			assertEquals("UPDATE", received.get().getAction().toUpperCase());
 		}
 	}
 
 	/**
-	 * Tests issue #138 deadlock claim: close() from another thread must
-	 * unblock a thread that is blocked on next(), without deadlocking.
+	 * Tests issue #138 deadlock claim: close() from another thread must unblock a
+	 * thread that is blocked on next(), without deadlocking.
 	 */
 	@Test
 	void closeUnblocksBlockedNext() throws Exception {
@@ -207,8 +201,7 @@ public class LiveQueryTests {
 				fail("next() threw instead of returning empty: " + error.get());
 			}
 			assertNotNull(result.get(), "next() should have returned after close()");
-			assertFalse(result.get().isPresent(),
-					"next() should return empty after stream is closed");
+			assertFalse(result.get().isPresent(), "next() should return empty after stream is closed");
 		}
 	}
 
@@ -274,8 +267,8 @@ public class LiveQueryTests {
 	}
 
 	/**
-	 * Verifies that selectLive() surfaces subscription errors immediately
-	 * rather than deferring them to the first next() call.
+	 * Verifies that selectLive() surfaces subscription errors immediately rather
+	 * than deferring them to the first next() call.
 	 */
 	@Test
 	void selectLiveOnNonExistentTableThrowsImmediately() {

--- a/src/test/java/com/surrealdb/QueryTests.java
+++ b/src/test/java/com/surrealdb/QueryTests.java
@@ -392,7 +392,7 @@ public class QueryTests {
 	}
 
 	@Test
-	void queryBind() throws SurrealException {
+	void queryBindRegression() throws SurrealException {
 		try (final Surreal surreal = new Surreal()) {
 			surreal.connect("memory").useNs("test_ns").useDb("test_db");
 			{
@@ -414,7 +414,29 @@ public class QueryTests {
 	}
 
 	@Test
-	void queryBindValues() throws SurrealException {
+	void queryWithBindings() throws SurrealException {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			{
+				final HashMap<String, String> map = new HashMap<>();
+				map.put("value", "hello");
+				map.put("value2", "world");
+				final String sql = "RETURN $value;RETURN $value2";
+				final Response response = surreal.query(sql, map);
+				{
+					final int size = response.size();
+					assertEquals(2, size);
+					final String res1 = response.take(0).getString();
+					assertEquals("hello", res1);
+					final String res2 = response.take(1).getString();
+					assertEquals("world", res2);
+				}
+			}
+		}
+	}
+
+	@Test
+	void queryWithBindingsValues() throws SurrealException {
 		try (final Surreal surreal = new Surreal()) {
 			surreal.connect("memory").useNs("test_ns").useDb("test_db");
 			{
@@ -431,7 +453,7 @@ public class QueryTests {
 				map.put("null", null);
 				map.put("uuid", UUID.fromString("f8e238f2-e734-47b8-9a16-476b291bd78a"));
 				final String sql2 = "RETURN [$string, $long, $list, $map, $array, $object, $null, $uuid]";
-				final Response response2 = surreal.queryBind(sql2, map);
+				final Response response2 = surreal.query(sql2, map);
 				{
 					final Array results = response2.take(0).getArray();
 					assertEquals(8, results.len());
@@ -467,7 +489,7 @@ public class QueryTests {
 				map.put("null", ValueMut.createNull());
 				map.put("none", ValueMut.createNone());
 				final String sql = "RETURN $null;RETURN $none";
-				final Response response = surreal.queryBind(sql, map);
+				final Response response = surreal.query(sql, map);
 				{
 					final int size = response.size();
 					assertEquals(2, size);

--- a/src/test/java/com/surrealdb/TransactionTests.java
+++ b/src/test/java/com/surrealdb/TransactionTests.java
@@ -1,5 +1,8 @@
 package com.surrealdb;
 
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,12 +36,49 @@ public class TransactionTests {
 	}
 
 	@Test
+	void transaction_queryWithBindings_returnsResponse() {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			Transaction txn = surreal.beginTransaction();
+			HashMap<String, String> map = new HashMap<>();
+			map.put("value", "hello");
+			map.put("value2", "world");
+			Response response = txn.query("RETURN $value;RETURN $value2", map);
+			assertNotNull(response);
+			assertEquals(2, response.size());
+			assertEquals("hello", response.take(0).getString());
+			assertEquals("world", response.take(1).getString());
+			txn.cancel();
+		}
+	}
+
+	@Test
 	void transaction_commit_succeeds() {
 		try (Surreal surreal = new Surreal()) {
 			surreal.connect("memory").useNs("test_ns").useDb("test_db");
 			Transaction txn = surreal.beginTransaction();
 			txn.query("INFO FOR DB");
 			txn.commit();
+		}
+	}
+
+	@Test
+	void transaction_queryWithBindings_commitsBoundData() {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			Transaction txn = surreal.beginTransaction();
+			HashMap<String, String> map = new HashMap<>();
+			map.put("name", "BoundTransaction");
+			Response create = txn.query("CREATE tx_bound SET name = $name", map);
+			assertNotNull(create);
+			assertTrue(create.size() >= 1);
+			txn.commit();
+			Response response = surreal.query("SELECT * FROM tx_bound WHERE name = 'BoundTransaction'");
+			assertNotNull(response);
+			Value first = response.take(0);
+			assertTrue(first.isArray());
+			assertEquals(1, first.getArray().len());
+			assertEquals("BoundTransaction", first.getArray().get(0).getObject().get("name").getString());
 		}
 	}
 

--- a/src/test/java/com/surrealdb/TransactionTests.java
+++ b/src/test/java/com/surrealdb/TransactionTests.java
@@ -1,6 +1,8 @@
 package com.surrealdb;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -79,6 +81,60 @@ public class TransactionTests {
 			assertTrue(first.isArray());
 			assertEquals(1, first.getArray().len());
 			assertEquals("BoundTransaction", first.getArray().get(0).getObject().get("name").getString());
+		}
+	}
+
+	@Test
+	void transaction_queryWithBindings_typeMatrix() {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final String sql1 = "RETURN [1, 2, 3];RETURN { foo: 'bar' }";
+			final Response response1 = surreal.query(sql1);
+			Transaction txn = surreal.beginTransaction();
+			final HashMap<String, java.lang.Object> map = new HashMap<>();
+			map.put("string", "hello_world");
+			map.put("long", 25565L);
+			map.put("list", Collections.singletonList("item1"));
+			map.put("map", Collections.singletonMap("foo", "bar"));
+			map.put("array", response1.take(0).getArray());
+			map.put("object", response1.take(1).getObject());
+			map.put("null", null);
+			map.put("uuid", UUID.fromString("f8e238f2-e734-47b8-9a16-476b291bd78a"));
+			final String sql2 = "RETURN [$string, $long, $list, $map, $array, $object, $null, $uuid]";
+			final Response response2 = txn.query(sql2, map);
+			final Array results = response2.take(0).getArray();
+			assertEquals(8, results.len());
+			assertEquals("hello_world", results.get(0).getString());
+			assertEquals(25565L, results.get(1).getLong());
+			final Array res3 = results.get(2).getArray();
+			assertEquals(1, res3.len());
+			assertEquals("item1", res3.get(0).getString());
+			final Object res4 = results.get(3).getObject();
+			assertEquals(1, res4.len());
+			assertEquals("bar", res4.get("foo").getString());
+			final Array res5 = results.get(4).getArray();
+			assertEquals("[1, 2, 3]", res5.toString());
+			final Object res6 = results.get(5).getObject();
+			assertEquals("{ foo: 'bar' }", res6.toString());
+			assertTrue(results.get(6).isNull());
+			assertEquals("f8e238f2-e734-47b8-9a16-476b291bd78a", results.get(7).getUuid().toString());
+			txn.cancel();
+		}
+	}
+
+	@Test
+	void transaction_queryWithBindings_valueMut() {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			Transaction txn = surreal.beginTransaction();
+			final HashMap<String, ValueMut> map = new HashMap<>();
+			map.put("null", ValueMut.createNull());
+			map.put("none", ValueMut.createNone());
+			final Response response = txn.query("RETURN $null;RETURN $none", map);
+			assertEquals(2, response.size());
+			assertTrue(response.take(0).isNull());
+			assertTrue(response.take(1).isNone());
+			txn.cancel();
 		}
 	}
 

--- a/src/test/java/com/surrealdb/TypeTests.java
+++ b/src/test/java/com/surrealdb/TypeTests.java
@@ -136,7 +136,8 @@ public class TypeTests {
 			// Starts an embedded in memory instance
 			surreal.connect("memory").useNs("test_ns").useDb("test_db");
 
-			// Test 1: Create a new record with byte[] data from raw bytes (use RecordId for deterministic selection)
+			// Test 1: Create a new record with byte[] data from raw bytes (use RecordId for
+			// deterministic selection)
 			final ByteData byteData = new ByteData();
 			byteData.data = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
 			final RecordId recordIdBytes = new RecordId("bytedata", "bytedata");
@@ -144,7 +145,8 @@ public class TypeTests {
 			// We check that the records are matching
 			assertEquals(created, byteData);
 
-			// Test 2: Create a new record with byte[] data converted from string (use RecordId for deterministic selection)
+			// Test 2: Create a new record with byte[] data converted from string (use
+			// RecordId for deterministic selection)
 			final ByteData byteDataFromString = new ByteData();
 			final String testString = "Hello";
 			byteDataFromString.data = testString.getBytes();
@@ -156,7 +158,8 @@ public class TypeTests {
 			final String retrievedString = new String(createdFromString.data);
 			assertEquals(retrievedString, testString);
 
-			// Test 3: Select from database by record id and verify byte[] is properly handled
+			// Test 3: Select from database by record id and verify byte[] is properly
+			// handled
 			final ByteData selectedRecord = surreal.select(ByteData.class, recordIdBytes)
 					.orElseThrow(() -> new AssertionError("Expected record to be present"));
 			// Compare the byte[] data content
@@ -169,7 +172,8 @@ public class TypeTests {
 			assertEquals(selectedRecord.data[0], 0x01);
 			assertEquals(selectedRecord.data[4], 0x05);
 
-			// Test 4: Select the string-converted record by record id and verify conversion back to
+			// Test 4: Select the string-converted record by record id and verify conversion
+			// back to
 			// string
 			final ByteData selectedStringRecord = surreal.select(ByteData.class, recordIdString)
 					.orElseThrow(() -> new AssertionError("Expected record to be present"));

--- a/src/test/java/com/surrealdb/ValueTypesTests.java
+++ b/src/test/java/com/surrealdb/ValueTypesTests.java
@@ -119,8 +119,8 @@ public class ValueTypesTests {
 	void recordIdArrayKeyAccessorsFromQuery() {
 		try (Surreal surreal = new Surreal()) {
 			surreal.connect("memory").useNs("test").useDb("test");
-			Response r = surreal.query(
-					"CREATE myDoc:['myTenant', 'myUlid'] CONTENT { name: 'jules', tenant: 'myTenant' }");
+			Response r = surreal
+					.query("CREATE myDoc:['myTenant', 'myUlid'] CONTENT { name: 'jules', tenant: 'myTenant' }");
 			Value v = r.take(0);
 			assertTrue(v.isArray());
 			RecordId recordId = v.getArray().get(0).getObject().get("id").getRecordId();


### PR DESCRIPTION
Closes #147

## Summary

This PR makes parameter binding more idiomatic in the Java SDK and adds missing binding support for client-side transactions.

The existing `Surreal.queryBind(...)` API is kept for backward compatibility, but now delegates to the new overloaded `Surreal.query(String, Map<String, ?>)` method.

## Changes

- Add `Surreal.query(String, Map<String, ?>)` as the canonical bound-query API.
- Deprecate `Surreal.queryBind(...)` and route it through the new overload.
- Add `Transaction.query(String, Map<String, ?>)` so transactional queries can safely bind parameters.
- Add JNI/Rust support for transaction query bindings using the same key/value packing path as regular client queries.
- Extract a shared `ValueBuilder.convertParams(Map<String, ?>)` helper used by both the `Surreal` and `Transaction` query overloads.
- Extract a shared `build_params_map!` Rust macro used by both `queryWithBindings` JNI entrypoints.
- Keep the public API Java 8-compatible.
- Apply Spotless formatting fixes.

## Testing

Added regression coverage for:

- `Surreal.query(String, Map<String, ?>)` bound queries.
- Deprecated `Surreal.queryBind(...)` continuing to work through the new path.
- `Transaction.query(String, Map<String, ?>)` returning bound values.
- Bound transactional writes becoming visible after commit.
- Transaction binding type matrix (string/long/list/map/array/object/null/UUID) mirroring the Surreal-side coverage.
- `ValueMut.createNull()` and `ValueMut.createNone()` bindings through transactions.

Validated with:

```bash
./gradlew test
```

## Reference-lifetime fix

During review, a JNI reference-lifetime issue was caught in an early version of the shared helper: it had returned a holder containing only the raw native pointers (`long[]`), so the temporary `ValueMut` Java wrappers became unreachable before the JNI call completed and could be finalized mid-flight. Resolved by having the caller hold the `Map<String, ValueMut>` as a local in the same stack frame as the JNI call — matching the existing convention used by `Surreal.run(...)` and every other JNI conversion site in the codebase.