### PR TITLE
ci: enforce formatting and scope GITHUB_TOKEN permissions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,8 +6,8 @@ root = true
 [*.java]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-indent_style = space
+indent_style = tab
+tab_width = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 100

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -14,6 +14,9 @@ on:
         required: false
         default: 'false'
 
+permissions:
+  contents: read
+
 jobs:
 
   android:

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -8,9 +8,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # required by the Deploy step (peaceiris/actions-gh-pages) on main
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,31 @@ on:
       - main
 
 jobs:
+  format:
+    name: Format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust (with rustfmt)
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          components: rustfmt
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Check Rust formatting
+        run: cargo fmt --all --check
+
+      - name: Check Java formatting
+        run: |
+          chmod +x gradlew
+          ./gradlew spotlessJavaCheck
+
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   format:
     name: Format check


### PR DESCRIPTION
## Summary

Two small CI hygiene improvements:

1. **Format enforcement** — new `Format check` job on PRs running `cargo fmt --all --check` and `./gradlew spotlessJavaCheck`.
2. **GITHUB_TOKEN permissions hardening** — explicit least-privilege `permissions:` blocks on all three workflows, fixing 8 CodeQL alerts.

Plus a one-line `.editorconfig` correction (codebase uses tabs; the file claimed spaces).

No source files reformatted.

## Why

**Format enforcement**: CI doesn't currently check formatting on either Java or Rust. Spotless is configured ([build.gradle:30-37](build.gradle)) but only runs when contributors invoke it manually — producing noisy "style: apply spotless fixes" commits inside otherwise-clean feature PRs (e.g. [#148](https://github.com/surrealdb/surrealdb.java/pull/148)).

**Permissions**: CodeQL flagged `actions/missing-workflow-permissions` on the workflow I touched. Investigating showed the same gap on the other two workflows (8 alerts total). Without explicit `permissions:` blocks, jobs inherit the default `GITHUB_TOKEN` scope, which is broader than needed.

## Changes

- **`.github/workflows/test.yml`** — new `format` job (JDK 17, stable Rust + rustfmt); workflow-level `permissions: contents: read`.
- **`.github/workflows/cross.yml`** — workflow-level `permissions: contents: read`. The `publish` job already declares its own `contents: read` + `packages: write` block, which job-level semantics keep intact.
- **`.github/workflows/reports.yml`** — workflow-level `permissions: contents: read` plus a job-level `permissions: contents: write` on `build` (required by the `peaceiris/actions-gh-pages` Deploy step on main).
- **`.editorconfig`** — `indent_style = space` / `indent_size = 4` → `indent_style = tab` / `tab_width = 4`. Matches the actual source and Spotless output.

## Verification

Both format checks pass on `main` today — confirmed locally before opening:

```bash
$ cargo fmt --all --check
$ ./gradlew spotlessJavaCheck
BUILD SUCCESSFUL
```

No source files reformatted by this PR. CI's `Format check` job is already green on the PR; `build` matrix still passes.

## Out of scope

A separate PR could migrate Spotless from `eclipse()` to `googleJavaFormat()` or `palantirJavaFormat()` for less aggressive Javadoc rewriting. That's a one-time reformat across all Java files — worth a dedicated change.

## Test plan

- [x] Local: `cargo fmt --all --check` and `./gradlew spotlessJavaCheck` pass on `main`
- [x] CI: `Format check` job passes on this PR
- [x] CI: `build` matrix (JDK 8/11/17/21/25) passes on this PR
- [ ] CodeQL re-scan confirms 0 remaining `actions/missing-workflow-permissions` alerts on these three files