### PR TITLE
Prepare release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.2] - 2026-05-20
+- Add Java query binding overloads and transaction bindings [#148](https://github.com/surrealdb/surrealdb.java/pull/148).
+- Enforce spotless/cargo fmt on PRs and scope GITHUB_TOKEN permissions [#150](https://github.com/surrealdb/surrealdb.java/pull/150).
+- Bump rustls-webpki from 0.103.9 to 0.103.13 [#146](https://github.com/surrealdb/surrealdb.java/pull/146).
+- Bump rand from 0.8.5 to 0.8.6 [#145](https://github.com/surrealdb/surrealdb.java/pull/145).
+- Bump lz4_flex from 0.12.0 to 0.12.1 [#144](https://github.com/surrealdb/surrealdb.java/pull/144).
+
 ## [2.0.1] - 2026-04-28
 - Upgrade to SurrealDB SDK 3.0.5.
 - Fix JVM crash when accessing array-backed RecordId keys [#141](https://github.com/surrealdb/surrealdb.java/pull/141).

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Gradle:
 
 ```groovy
 ext {
-    surrealdbVersion = "2.0.1"
+    surrealdbVersion = "2.0.2"
 }
 
 dependencies {
@@ -80,7 +80,7 @@ Maven:
 <dependency>
     <groupId>com.surrealdb</groupId>
     <artifactId>surrealdb</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
 }
 
 group 'com.surrealdb'
-version '2.0.2-SNAPSHOT'
+version '2.0.2'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary

Bumps the Java driver version to `2.0.2` (release), adds the `[2.0.2]` entry to `CHANGELOG.md`, and updates the README install examples to `2.0.2`.

## Changes

- Add Java query binding overloads and transaction bindings (#148).
- Enforce spotless/cargo fmt on PRs and scope GITHUB_TOKEN permissions (#150).
- Bump rustls-webpki from 0.103.9 to 0.103.13 (#146).
- Bump rand from 0.8.5 to 0.8.6 (#145).
- Bump lz4_flex from 0.12.0 to 0.12.1 (#144).

**Full Changelog**: https://github.com/surrealdb/surrealdb.java/compare/v2.0.1...release/2.0.2

## Release plan

After this PR merges:
1. Manually dispatch the **Cross-Compile** workflow on `main` with `Publish? = true` to publish to Maven Central and GitHub Packages.
2. Tag the merge commit as `v2.0.2` and create a GitHub Release.
3. Open a follow-up PR bumping the version to `2.0.3-SNAPSHOT`.

## Test plan
- [ ] `test.yml` CI passes (format checks + JDK 8/11/17/21/25 builds)
- [ ] `cross.yml` CI passes (cross-compile + integration tests on Linux/macOS/Windows)