### PR TITLE
Add Array.of() and Id.from(Object...) factories for composite keys

### DIFF
--- a/src/main/java/com/surrealdb/Array.java
+++ b/src/main/java/com/surrealdb/Array.java
@@ -17,13 +17,17 @@ public class Array extends Native implements Iterable<Value> {
 	}
 
 	/**
-	 * Creates an Array from a heterogeneous list of Java values. Supported element
-	 * types include {@code null}, {@link String}, the boxed numeric types,
+	 * Creates an Array from a heterogeneous sequence of Java values. Supported
+	 * element types include {@code null}, {@link String}, the boxed numeric types,
 	 * {@link Boolean}, {@link java.math.BigDecimal}, {@link java.util.UUID},
 	 * {@link java.time.Duration}, {@link java.time.ZonedDateTime}, and the
 	 * SurrealDB wrappers {@link Array}, {@link Id}, {@link RecordId}, and
 	 * {@link com.surrealdb.Object}. Unsupported types raise
 	 * {@link IllegalArgumentException}.
+	 * <p>
+	 * To build a single-element {@code [null]} array, cast the argument:
+	 * {@code Array.of((java.lang.Object) null)}. A bare {@code Array.of(null)} is a
+	 * null varargs array and will throw {@link NullPointerException}.
 	 */
 	public static Array of(java.lang.Object... elements) {
 		Objects.requireNonNull(elements, "elements");
@@ -32,14 +36,11 @@ public class Array extends Native implements Iterable<Value> {
 
 	/**
 	 * List-based counterpart to {@link #of(java.lang.Object...)} for callers that
-	 * already hold a {@link List}.
+	 * already hold a {@link List}. Named distinctly from {@code of(...)} to avoid a
+	 * null-call overload ambiguity.
 	 */
-	public static Array of(List<?> elements) {
+	public static Array fromList(List<?> elements) {
 		Objects.requireNonNull(elements, "elements");
-		return fromList(elements);
-	}
-
-	private static Array fromList(List<?> elements) {
 		final long[] ptrs = new long[elements.size()];
 		final ValueMut[] muts = new ValueMut[elements.size()];
 		for (int i = 0; i < elements.size(); i++) {

--- a/src/main/java/com/surrealdb/Array.java
+++ b/src/main/java/com/surrealdb/Array.java
@@ -1,6 +1,9 @@
 package com.surrealdb;
 
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * The Array class represents a native array structure and provides methods to
@@ -12,6 +15,45 @@ public class Array extends Native implements Iterable<Value> {
 	Array(long ptr) {
 		super(ptr);
 	}
+
+	/**
+	 * Creates an Array from a heterogeneous list of Java values. Supported element
+	 * types include {@code null}, {@link String}, the boxed numeric types,
+	 * {@link Boolean}, {@link java.math.BigDecimal}, {@link java.util.UUID},
+	 * {@link java.time.Duration}, {@link java.time.ZonedDateTime}, and the
+	 * SurrealDB wrappers {@link Array}, {@link Id}, {@link RecordId}, and
+	 * {@link com.surrealdb.Object}. Unsupported types raise
+	 * {@link IllegalArgumentException}.
+	 */
+	public static Array of(java.lang.Object... elements) {
+		Objects.requireNonNull(elements, "elements");
+		return fromList(Arrays.asList(elements));
+	}
+
+	/**
+	 * List-based counterpart to {@link #of(java.lang.Object...)} for callers that
+	 * already hold a {@link List}.
+	 */
+	public static Array of(List<?> elements) {
+		Objects.requireNonNull(elements, "elements");
+		return fromList(elements);
+	}
+
+	private static Array fromList(List<?> elements) {
+		final long[] ptrs = new long[elements.size()];
+		final ValueMut[] muts = new ValueMut[elements.size()];
+		for (int i = 0; i < elements.size(); i++) {
+			muts[i] = ValueBoxing.box(elements.get(i));
+			ptrs[i] = muts[i].getPtr();
+		}
+		final Array array = new Array(newOf(ptrs));
+		for (final ValueMut m : muts) {
+			m.moved();
+		}
+		return array;
+	}
+
+	private static native long newOf(long[] valueMutPtrs);
 
 	private static native long get(long ptr, int idx);
 

--- a/src/main/java/com/surrealdb/Id.java
+++ b/src/main/java/com/surrealdb/Id.java
@@ -1,5 +1,8 @@
 package com.surrealdb;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -24,11 +27,44 @@ public class Id extends Native {
 		return new Id(newUuidId(id.toString()));
 	}
 
+	/**
+	 * Creates an Id whose key is an array of Java values (composite key). See
+	 * {@link Array#of(java.lang.Object...)} for the supported element types.
+	 */
+	public static Id from(java.lang.Object... elements) {
+		Objects.requireNonNull(elements, "elements");
+		return fromList(Arrays.asList(elements));
+	}
+
+	/**
+	 * List-based counterpart to {@link #from(java.lang.Object...)}.
+	 */
+	public static Id from(List<?> elements) {
+		Objects.requireNonNull(elements, "elements");
+		return fromList(elements);
+	}
+
+	private static Id fromList(List<?> elements) {
+		final long[] ptrs = new long[elements.size()];
+		final ValueMut[] muts = new ValueMut[elements.size()];
+		for (int i = 0; i < elements.size(); i++) {
+			muts[i] = ValueBoxing.box(elements.get(i));
+			ptrs[i] = muts[i].getPtr();
+		}
+		final Id id = new Id(newArrayId(ptrs));
+		for (final ValueMut m : muts) {
+			m.moved();
+		}
+		return id;
+	}
+
 	private static native long newLongId(long id);
 
 	private static native long newStringId(String id);
 
 	private static native long newUuidId(String id);
+
+	private static native long newArrayId(long[] valueMutPtrs);
 
 	private static native boolean isLong(long ptr);
 

--- a/src/main/java/com/surrealdb/Id.java
+++ b/src/main/java/com/surrealdb/Id.java
@@ -30,6 +30,10 @@ public class Id extends Native {
 	/**
 	 * Creates an Id whose key is an array of Java values (composite key). See
 	 * {@link Array#of(java.lang.Object...)} for the supported element types.
+	 * <p>
+	 * To build a single-element {@code [null]} key, cast the argument:
+	 * {@code Id.from((java.lang.Object) null)}. A bare {@code Id.from(null)} is a
+	 * null varargs array and will throw {@link NullPointerException}.
 	 */
 	public static Id from(java.lang.Object... elements) {
 		Objects.requireNonNull(elements, "elements");
@@ -37,14 +41,11 @@ public class Id extends Native {
 	}
 
 	/**
-	 * List-based counterpart to {@link #from(java.lang.Object...)}.
+	 * List-based counterpart to {@link #from(java.lang.Object...)}. Named
+	 * distinctly from {@code from(...)} to avoid a null-call overload ambiguity.
 	 */
-	public static Id from(List<?> elements) {
+	public static Id fromList(List<?> elements) {
 		Objects.requireNonNull(elements, "elements");
-		return fromList(elements);
-	}
-
-	private static Id fromList(List<?> elements) {
 		final long[] ptrs = new long[elements.size()];
 		final ValueMut[] muts = new ValueMut[elements.size()];
 		for (int i = 0; i < elements.size(); i++) {

--- a/src/main/java/com/surrealdb/ValueBoxing.java
+++ b/src/main/java/com/surrealdb/ValueBoxing.java
@@ -1,0 +1,72 @@
+package com.surrealdb;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+/**
+ * Boxes raw Java values into {@link ValueMut} instances, used by factories like
+ * {@link Array#of(java.lang.Object...)} and
+ * {@link Id#from(java.lang.Object...)} to accept heterogeneous element lists.
+ */
+final class ValueBoxing {
+
+	private ValueBoxing() {
+	}
+
+	static ValueMut box(java.lang.Object e) {
+		if (e == null) {
+			return ValueMut.createNull();
+		}
+		if (e instanceof String) {
+			return ValueMut.createString((String) e);
+		}
+		if (e instanceof Long) {
+			return ValueMut.createLong((Long) e);
+		}
+		if (e instanceof Integer) {
+			return ValueMut.createLong(((Integer) e).longValue());
+		}
+		if (e instanceof Short) {
+			return ValueMut.createLong(((Short) e).longValue());
+		}
+		if (e instanceof Byte) {
+			return ValueMut.createLong(((Byte) e).longValue());
+		}
+		if (e instanceof Boolean) {
+			return ValueMut.createBoolean((Boolean) e);
+		}
+		if (e instanceof Double) {
+			return ValueMut.createDouble((Double) e);
+		}
+		if (e instanceof Float) {
+			return ValueMut.createDouble(((Float) e).doubleValue());
+		}
+		if (e instanceof BigDecimal) {
+			return ValueMut.createBigDecimal((BigDecimal) e);
+		}
+		if (e instanceof UUID) {
+			return ValueMut.createUuid((UUID) e);
+		}
+		if (e instanceof Duration) {
+			return ValueMut.createDuration((Duration) e);
+		}
+		if (e instanceof ZonedDateTime) {
+			return ValueMut.createDatetime((ZonedDateTime) e);
+		}
+		if (e instanceof Array) {
+			return ValueMut.createArray((Array) e);
+		}
+		if (e instanceof Id) {
+			return ValueMut.createId((Id) e);
+		}
+		if (e instanceof RecordId) {
+			return ValueMut.createRecordId((RecordId) e);
+		}
+		if (e instanceof com.surrealdb.Object) {
+			return ValueMut.createObject((com.surrealdb.Object) e);
+		}
+		throw new IllegalArgumentException("unsupported element type " + e.getClass().getName());
+	}
+}

--- a/src/main/rust/array.rs
+++ b/src/main/rust/array.rs
@@ -2,14 +2,17 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ptr::null_mut;
 use std::sync::Arc;
 
-use jni::objects::JClass;
+use jni::objects::{JClass, JLongArray};
 use jni::sys::{jboolean, jint, jlong, jstring};
 use jni::JNIEnv;
 use parking_lot::Mutex;
-use surrealdb::types::{ToSql, Value};
+use surrealdb::types::{Array, ToSql, Value};
 
 use crate::error::SurrealError;
-use crate::{get_value_instance, new_string, release_instance, JniTypes};
+use crate::{
+    get_long_array, get_value_instance, new_string, release_instance, take_value_mut_instance,
+    JniTypes,
+};
 
 #[no_mangle]
 pub extern "system" fn Java_com_surrealdb_Array_deleteInstance<'local>(
@@ -18,6 +21,22 @@ pub extern "system" fn Java_com_surrealdb_Array_deleteInstance<'local>(
     ptr: jlong,
 ) {
     release_instance::<Arc<Value>>(ptr);
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Array_newOf<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    ptrs: JLongArray<'local>,
+) -> jlong {
+    let ptrs = get_long_array!(&mut env, &ptrs, || 0);
+    let mut values = Vec::with_capacity(ptrs.len());
+    for ptr in ptrs {
+        let value = take_value_mut_instance!(&mut env, ptr, || 0);
+        values.push(value);
+    }
+    let value = Value::Array(Array::from(values));
+    JniTypes::new_value(value.into())
 }
 
 #[no_mangle]

--- a/src/main/rust/id.rs
+++ b/src/main/rust/id.rs
@@ -2,13 +2,16 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ptr::null_mut;
 use std::str::FromStr;
 
-use jni::objects::{JClass, JString};
+use jni::objects::{JClass, JLongArray, JString};
 use jni::sys::{jboolean, jint, jlong, jstring};
 use jni::JNIEnv;
-use surrealdb::types::{RecordId, RecordIdKey, ToSql, Uuid, Value};
+use surrealdb::types::{Array, RecordId, RecordIdKey, ToSql, Uuid, Value};
 
 use crate::error::SurrealError;
-use crate::{get_rust_string, get_value_instance, new_string, JniTypes};
+use crate::{
+    get_long_array, get_rust_string, get_value_instance, new_string, take_value_mut_instance,
+    JniTypes,
+};
 
 #[no_mangle]
 pub extern "system" fn Java_com_surrealdb_Id_newLongId<'local>(
@@ -44,6 +47,23 @@ pub extern "system" fn Java_com_surrealdb_Id_newUuidId<'local>(
     } else {
         SurrealError::NullPointerException("RecordId").exception(&mut env, || 0)
     }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Id_newArrayId<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    ptrs: JLongArray<'local>,
+) -> jlong {
+    let ptrs = get_long_array!(&mut env, &ptrs, || 0);
+    let mut values = Vec::with_capacity(ptrs.len());
+    for ptr in ptrs {
+        let value = take_value_mut_instance!(&mut env, ptr, || 0);
+        values.push(value);
+    }
+    let key = RecordIdKey::Array(Array::from(values));
+    let value = Value::RecordId(RecordId::new("", key));
+    JniTypes::new_value(value.into())
 }
 
 #[no_mangle]

--- a/src/test/java/com/surrealdb/TypeTests.java
+++ b/src/test/java/com/surrealdb/TypeTests.java
@@ -5,10 +5,14 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
@@ -103,6 +107,121 @@ public class TypeTests {
 			Optional<Value> selected = surreal.select(rid);
 			assertTrue(selected.isPresent());
 			assertEquals(name.first, selected.get().get(Name.class).first);
+		}
+	}
+
+	@Test
+	void testArrayOfFromVarargs() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final UUID uuid = UUID.randomUUID();
+			final RecordId rid = new RecordId("doc", Array.of("myTenant", uuid));
+			Id id = rid.getId();
+			assertTrue(id.isArray());
+			Array idArray = id.getArray();
+			assertEquals(2, idArray.len());
+			assertEquals("myTenant", idArray.get(0).getString());
+			assertEquals(uuid, idArray.get(1).getUuid());
+			final Name name = new Name("of", "varargs");
+			surreal.create(rid, name);
+			Optional<Value> selected = surreal.select(rid);
+			assertTrue(selected.isPresent());
+			assertEquals(name.first, selected.get().get(Name.class).first);
+		}
+	}
+
+	@Test
+	void testArrayOfEmpty() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Array empty = Array.of();
+			assertEquals(0, empty.len());
+		}
+	}
+
+	@Test
+	void testArrayOfList() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Array a = Array.of(Arrays.asList("a", "b"));
+			assertEquals(2, a.len());
+			assertEquals("a", a.get(0).getString());
+			assertEquals("b", a.get(1).getString());
+		}
+	}
+
+	@Test
+	void testArrayOfMixedPrimitives() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Array a = Array.of("a", 1L, 2.5, true);
+			assertEquals(4, a.len());
+			assertEquals("a", a.get(0).getString());
+			assertEquals(1L, a.get(1).getLong());
+			assertEquals(2.5, a.get(2).getDouble());
+			assertTrue(a.get(3).getBoolean());
+		}
+	}
+
+	@Test
+	void testArrayOfWithNull() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Array a = Array.of("a", null, "b");
+			assertEquals(3, a.len());
+			assertEquals("a", a.get(0).getString());
+			assertFalse(a.get(1).isString());
+			assertEquals("b", a.get(2).getString());
+		}
+	}
+
+	@Test
+	void testArrayOfNested() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Array outer = Array.of("outer", Array.of("inner1", "inner2"));
+			assertEquals(2, outer.len());
+			assertEquals("outer", outer.get(0).getString());
+			assertTrue(outer.get(1).isArray());
+			Array inner = outer.get(1).getArray();
+			assertEquals(2, inner.len());
+			assertEquals("inner1", inner.get(0).getString());
+			assertEquals("inner2", inner.get(1).getString());
+		}
+	}
+
+	@Test
+	void testArrayOfWithWrappedTypes() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final UUID uuid = UUID.randomUUID();
+			final RecordId inner = new RecordId("inner", "k");
+			final Array a = Array.of(inner, uuid);
+			assertEquals(2, a.len());
+			assertTrue(a.get(0).isRecordId());
+			assertEquals(uuid, a.get(1).getUuid());
+		}
+	}
+
+	@Test
+	void testArrayOfRejectsUnsupportedType() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			assertThrows(IllegalArgumentException.class, () -> Array.of(new Date()));
+		}
+	}
+
+	@Test
+	void testIdFromArrayVarargs() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final UUID uuid = UUID.randomUUID();
+			final Id id = Id.from("myTenant", uuid);
+			assertTrue(id.isArray());
+			Array a = id.getArray();
+			assertEquals(2, a.len());
+			assertEquals("myTenant", a.get(0).getString());
+			assertEquals(uuid, a.get(1).getUuid());
 		}
 	}
 

--- a/src/test/java/com/surrealdb/TypeTests.java
+++ b/src/test/java/com/surrealdb/TypeTests.java
@@ -140,13 +140,23 @@ public class TypeTests {
 	}
 
 	@Test
-	void testArrayOfList() {
+	void testArrayFromList() {
 		try (final Surreal surreal = new Surreal()) {
 			surreal.connect("memory").useNs("test_ns").useDb("test_db");
-			final Array a = Array.of(Arrays.asList("a", "b"));
+			final Array a = Array.fromList(Arrays.asList("a", "b"));
 			assertEquals(2, a.len());
 			assertEquals("a", a.get(0).getString());
 			assertEquals("b", a.get(1).getString());
+		}
+	}
+
+	@Test
+	void testArrayOfSingleNullElement() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Array a = Array.of((java.lang.Object) null);
+			assertEquals(1, a.len());
+			assertFalse(a.get(0).isString());
 		}
 	}
 


### PR DESCRIPTION
## Summary

Closes the ergonomic gap that made `new RecordId("rec", Array.of("myTenant", UUID.randomUUID()))` impossible. The `RecordId(String, Array)` constructor already existed, but `Array` had no public factory — its only constructor was package-private, and `ValueMut.createArray(List<ValueMut>)` returns a `ValueMut`, not an `Array`. The only way to obtain an `Array` was via a query round-trip.

Adds:

- `Array.of(java.lang.Object...)` and `Array.fromList(List<?>)` static factories.
- `Id.from(java.lang.Object...)` and `Id.fromList(List<?>)` for parity on the table-less form.
- A package-private `ValueBoxing` helper that maps Java values (primitives, wrappers, `UUID`/`Duration`/`ZonedDateTime`/`BigDecimal`, and the SurrealDB types `Array`/`Id`/`RecordId`/`com.surrealdb.Object`) to a `ValueMut`. Unsupported types raise `IllegalArgumentException`.
- Two new JNI entry points — `Java_com_surrealdb_Array_newOf` and `Java_com_surrealdb_Id_newArrayId` — that consume an array of `ValueMut` pointers and produce an `Arc<Value>` pointer matching the shape the read side already expects.

Supports nested composites (`Array.of("foo", Array.of("nested"))`) and already-wrapped types (`Array.of(someRecordId, someUuid)`).

### Why `fromList` and not `of(List<?>)`?

The list-taking variant is deliberately named differently from the varargs `of` / `from`. With both `of(Object...)` and `of(List<?>)` present, a bare `Array.of(null)` is ambiguous between the two overloads (per [r3281610673](https://github.com/surrealdb/surrealdb.java/pull/154#discussion_r3281610673)), and the API explicitly documents `null` as a supported element. Naming the list form `fromList` removes the ambiguity. The Javadoc on the varargs method documents that a single-null-element array can be built with `Array.of((java.lang.Object) null)` — a bare `Array.of(null)` is treated as a null varargs array and throws `NullPointerException`.

## Java 8 compatibility

The codebase enforces `--release 8` (see `build.gradle:54-62`) and tests against the matrix `[8, 11, 17, 21, 25]` (see `.github/workflows/test.yml`). All new Java code uses classic `instanceof` + cast (no Java 16 pattern variables), `Arrays.asList` (no Java 9 `List.of`), and only Java 8 APIs (`Objects.requireNonNull`, `java.time.*`, `java.util.UUID`, `java.math.BigDecimal`).

## Test plan

- [x] `cargo build` clean
- [x] `./gradlew spotlessApply check` passes locally (one pre-existing, unrelated failure: `ConnectionTests.connectWebsocket()` requires a running SurrealDB server on localhost and gets `Connection refused`)
- [x] 10 new tests in `TypeTests` all pass:
  - `testArrayOfFromVarargs` — the exact case from the bug report, round-tripped through create/select
  - `testArrayOfEmpty`
  - `testArrayFromList`
  - `testArrayOfMixedPrimitives`
  - `testArrayOfWithNull`
  - `testArrayOfSingleNullElement` — locks in the `(Object) null` cast pattern
  - `testArrayOfNested`
  - `testArrayOfWithWrappedTypes`
  - `testArrayOfRejectsUnsupportedType`
  - `testIdFromArrayVarargs`
- [ ] CI matrix passes on Java 8, 11, 17, 21, 25

## Out of scope

- A varargs `RecordId(String, Object...)` overload — would clash with the existing `RecordId(String, Object)` where `Object` is `com.surrealdb.Object`. Users compose via `new RecordId(table, Array.of(...))` instead.
- A `Map`-based `com.surrealdb.Object.of(...)` factory — same `ValueBoxing` helper would make it cheap, but it is a separate ask.