### PR TITLE
Fix nullable Boolean and Optional<T> (de)serialization

### DIFF
--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -75,7 +75,7 @@ class ValueBuilder {
 		}
 		if (object instanceof Optional) {
 			final Optional<?> optional = (Optional<?>) object;
-			return optional.map(ValueBuilder::convert).orElse(null);
+			return optional.map(ValueBuilder::convert).orElseGet(ValueMut::createNull);
 		}
 		if (object instanceof Id) {
 			return ValueMut.createId((Id) object);

--- a/src/main/java/com/surrealdb/ValueClassConverter.java
+++ b/src/main/java/com/surrealdb/ValueClassConverter.java
@@ -1,6 +1,7 @@
 package com.surrealdb;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -50,7 +51,11 @@ class ValueClassConverter<T> {
 		if (value.isNull()) {
 			field.set(target, null);
 		} else if (value.isBoolean()) {
-			field.setBoolean(target, value.getBoolean());
+			final boolean b = value.getBoolean();
+			if (type == Boolean.TYPE)
+				field.setBoolean(target, b);
+			else
+				field.set(target, b);
 		} else if (value.isDouble()) {
 			final double d = value.getDouble();
 			if (type == Double.TYPE)
@@ -121,6 +126,7 @@ class ValueClassConverter<T> {
 
 	private static <T> T convert(Class<T> clazz, Object source) throws ReflectiveOperationException {
 		final T target = clazz.getConstructor().newInstance();
+		initOptionalFields(clazz, target);
 		for (final Entry entry : source) {
 			try {
 				final String key = entry.getKey();
@@ -203,6 +209,25 @@ class ValueClassConverter<T> {
 			}
 		} else {
 			setSingleValue(field, type, target, value);
+		}
+	}
+
+	private static <T> void initOptionalFields(Class<?> clazz, T target) throws IllegalAccessException {
+		Class<?> c = clazz;
+		while (c != null && c != java.lang.Object.class) {
+			for (final Field field : c.getDeclaredFields()) {
+				int mods = field.getModifiers();
+				if (Modifier.isStatic(mods) || Modifier.isTransient(mods)) {
+					continue;
+				}
+				if (Optional.class.equals(field.getType())) {
+					field.setAccessible(true);
+					if (field.get(target) == null) {
+						field.set(target, Optional.empty());
+					}
+				}
+			}
+			c = c.getSuperclass();
 		}
 	}
 

--- a/src/test/java/com/surrealdb/BooleanOptionalTests.java
+++ b/src/test/java/com/surrealdb/BooleanOptionalTests.java
@@ -18,7 +18,8 @@ public class BooleanOptionalTests {
 	void allPresent() {
 		try (final Surreal surreal = new Surreal()) {
 			surreal.connect("memory").useNs("test_ns").useDb("test_db");
-			final Booleans b = new Booleans(true, Boolean.TRUE, Optional.of(false), Optional.of(Arrays.asList("a", "b")));
+			final Booleans b = new Booleans(true, Boolean.TRUE, Optional.of(false),
+					Optional.of(Arrays.asList("a", "b")));
 			final RecordId rid = new RecordId("booleans", "all");
 			final Booleans created = surreal.create(Booleans.class, rid, b);
 			assertEquals(b, created);

--- a/src/test/java/com/surrealdb/BooleanOptionalTests.java
+++ b/src/test/java/com/surrealdb/BooleanOptionalTests.java
@@ -1,0 +1,112 @@
+package com.surrealdb;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import com.surrealdb.pojos.Booleans;
+
+public class BooleanOptionalTests {
+
+	@Test
+	void allPresent() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Booleans b = new Booleans(true, Boolean.TRUE, Optional.of(false), Optional.of(Arrays.asList("a", "b")));
+			final RecordId rid = new RecordId("booleans", "all");
+			final Booleans created = surreal.create(Booleans.class, rid, b);
+			assertEquals(b, created);
+			final Booleans selected = surreal.select(Booleans.class, rid)
+					.orElseThrow(() -> new AssertionError("Expected record to be present"));
+			assertEquals(b, selected);
+		}
+	}
+
+	@Test
+	void boxedFalseRoundTrip() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Booleans b = new Booleans(false, Boolean.FALSE, Optional.of(true), Optional.empty());
+			final RecordId rid = new RecordId("booleans", "boxed_false");
+			final Booleans created = surreal.create(Booleans.class, rid, b);
+			assertEquals(b, created);
+			final Booleans selected = surreal.select(Booleans.class, rid)
+					.orElseThrow(() -> new AssertionError("Expected record to be present"));
+			assertEquals(b, selected);
+		}
+	}
+
+	@Test
+	void boxedNullIsDropped() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Booleans b = new Booleans(true, null, Optional.of(false), Optional.of(Arrays.asList("x")));
+			final RecordId rid = new RecordId("booleans", "boxed_null");
+			final Booleans created = surreal.create(Booleans.class, rid, b);
+			assertNull(created.boxed);
+			assertTrue(created.primitive);
+			assertEquals(Optional.of(false), created.opt);
+			final Booleans selected = surreal.select(Booleans.class, rid)
+					.orElseThrow(() -> new AssertionError("Expected record to be present"));
+			assertNull(selected.boxed);
+			assertTrue(selected.primitive);
+			assertEquals(Optional.of(false), selected.opt);
+		}
+	}
+
+	@Test
+	void optionalEmptyRoundTrip() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Booleans b = new Booleans(true, Boolean.TRUE, Optional.empty(), Optional.empty());
+			final RecordId rid = new RecordId("booleans", "opt_empty");
+			final Booleans created = surreal.create(Booleans.class, rid, b);
+			assertNotNull(created.opt);
+			assertEquals(Optional.empty(), created.opt);
+			assertNotNull(created.optList);
+			assertEquals(Optional.empty(), created.optList);
+			final Booleans selected = surreal.select(Booleans.class, rid)
+					.orElseThrow(() -> new AssertionError("Expected record to be present"));
+			assertNotNull(selected.opt);
+			assertEquals(Optional.empty(), selected.opt);
+			assertNotNull(selected.optList);
+			assertEquals(Optional.empty(), selected.optList);
+		}
+	}
+
+	@Test
+	void missingEntryDefaultsToOptionalEmpty() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			surreal.query("CREATE booleans:missing SET primitive = true");
+			final Booleans selected = surreal.select(Booleans.class, new RecordId("booleans", "missing"))
+					.orElseThrow(() -> new AssertionError("Expected record to be present"));
+			assertTrue(selected.primitive);
+			assertNull(selected.boxed);
+			assertNotNull(selected.opt);
+			assertEquals(Optional.empty(), selected.opt);
+			assertNotNull(selected.optList);
+			assertEquals(Optional.empty(), selected.optList);
+		}
+	}
+
+	@Test
+	void optionalListPresent() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final List<String> list = Arrays.asList("foo", "bar", "baz");
+			final Booleans b = new Booleans(true, Boolean.TRUE, Optional.of(true), Optional.of(list));
+			final RecordId rid = new RecordId("booleans", "opt_list");
+			surreal.create(Booleans.class, rid, b);
+			final Booleans selected = surreal.select(Booleans.class, rid)
+					.orElseThrow(() -> new AssertionError("Expected record to be present"));
+			assertEquals(Optional.of(list), selected.optList);
+		}
+	}
+}

--- a/src/test/java/com/surrealdb/pojos/Booleans.java
+++ b/src/test/java/com/surrealdb/pojos/Booleans.java
@@ -1,0 +1,44 @@
+package com.surrealdb.pojos;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class Booleans {
+
+	public boolean primitive;
+	public Boolean boxed;
+	public Optional<Boolean> opt;
+	public Optional<List<String>> optList;
+
+	public Booleans() {
+	}
+
+	public Booleans(boolean primitive, Boolean boxed, Optional<Boolean> opt, Optional<List<String>> optList) {
+		this.primitive = primitive;
+		this.boxed = boxed;
+		this.opt = opt;
+		this.optList = optList;
+	}
+
+	@Override
+	public boolean equals(java.lang.Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		final Booleans b = (Booleans) o;
+		return primitive == b.primitive && Objects.equals(boxed, b.boxed) && Objects.equals(opt, b.opt)
+				&& Objects.equals(optList, b.optList);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(primitive, boxed, opt, optList);
+	}
+
+	@Override
+	public String toString() {
+		return "primitive=" + primitive + ", boxed=" + boxed + ", opt=" + opt + ", optList=" + optList;
+	}
+}


### PR DESCRIPTION
## Summary

Three related bugs prevented round-tripping nullable `Boolean` and `Optional<T>` fields between POJOs and SurrealDB. All three are fixed; the public API and existing behavior for non-nullable fields are unchanged.

### 1. Boxed `Boolean` always failed to deserialize

[`ValueClassConverter.setSingleValue`](https://github.com/surrealdb/surrealdb.java/blob/fix-nullable-boolean-optional/src/main/java/com/surrealdb/ValueClassConverter.java) called `field.setBoolean()` regardless of whether the field was the primitive `boolean` or the boxed `Boolean`. `Field.setBoolean()` only works on primitive fields — for `Boolean` it threw `IllegalArgumentException`. The same file already had the right pattern for `Integer`/`Short` (separate branch for `*.TYPE` vs `*.class`); `Boolean` was just missed.

Fixed by mirroring the Integer/Short pattern.

### 2. `Optional.empty()` crashed serialization with NPE

`ValueBuilder.convertObject`'s `Optional` branch returned a Java `null` (`optional.map(...).orElse(null)`), which then propagated into `EntryMut.newEntry(name, null)` → `value.getPtr()` → NullPointerException.

Fixed by returning `ValueMut.createNull()` for empty optionals. This is symmetric with the existing deserialization path: `setFieldSingleValue` already maps `value.isNull()` to `Optional.empty()`.

### 3. Missing entries left `Optional<T>` fields as `null` after deserialization

`ValueClassConverter.convert(Class, Object)` only iterated over entries present in the source object. If a field was absent (because the producer skipped a null field, or because the record was created via raw SurrealQL without that column), the Java field stayed at its default `null` — even when its declared type was `Optional<T>`. Callers had to defensively write `obj.field == null ? ... : obj.field.orElse(...)`.

Fixed by pre-initializing every `Optional`-typed field to `Optional.empty()` immediately after `newInstance()`. Walks the class hierarchy to match the existing `getInheritedDeclaredField` semantics.

## What works now

### Boxed `Boolean` (nullable) round-trip

\`\`\`java
public class MyObj {
    public Boolean success; // boxed — can be null
}

try (var surreal = new Surreal()) {
    surreal.connect("memory").useNs("ns").useDb("db");

    // Both true/false and null serialize cleanly
    surreal.create(MyObj.class, new RecordId("docs", "ok"),   new MyObj(true));
    surreal.create(MyObj.class, new RecordId("docs", "fail"), new MyObj(false));

    // Deserialization no longer throws IllegalArgumentException
    MyObj doc = surreal.select(MyObj.class, new RecordId("docs", "ok")).orElseThrow();
    System.out.println(doc.success); // true
}
\`\`\`

### `Optional<T>` with `Optional.empty()`

\`\`\`java
public class MyObj {
    public Optional<Boolean> success;
    public Optional<List<String>> tags;
}

try (var surreal = new Surreal()) {
    surreal.connect("memory").useNs("ns").useDb("db");

    // Optional.empty() no longer NPEs — it serializes as NULL
    var rid = new RecordId("docs", "1");
    surreal.create(MyObj.class, rid, new MyObj(Optional.empty(), Optional.of(List.of("a", "b"))));

    MyObj doc = surreal.select(MyObj.class, rid).orElseThrow();
    System.out.println(doc.success); // Optional.empty
    System.out.println(doc.tags);    // Optional[[a, b]]
}
\`\`\`

### Missing entries now default to `Optional.empty()` on deserialization

\`\`\`java
// Record created without the `success` field at all
surreal.query("CREATE docs:legacy SET name = 'foo'");

MyObj doc = surreal.select(MyObj.class, new RecordId("docs", "legacy")).orElseThrow();

// Before: doc.success was null, callers needed obj.success == null ? ... : obj.success.orElse(...)
// After:
boolean ok = doc.success.orElse(false); // just works
\`\`\`

## Behavior preserved

Null non-`Optional` fields (e.g. `Boolean success = null`) continue to be silently skipped during serialization. We considered changing this to send explicit NULL but kept the current behavior to avoid breaking schemafull tables where the column doesn't allow NULL.

## Testing

Added `Booleans` POJO and `BooleanOptionalTests` with six round-trip cases:

- `allPresent` — exercises Bug 1 fix
- `boxedFalseRoundTrip` — boxed `Boolean.FALSE` round-trip
- `boxedNullIsDropped` — confirms current skip-on-null behavior is preserved
- `optionalEmptyRoundTrip` — exercises Bug 2 fix
- `missingEntryDefaultsToOptionalEmpty` — exercises Bug 3 fix using raw SurrealQL to create a record without the field
- `optionalListPresent` — proves the Optional fix is generic, not Boolean-specific

## Test plan

- [x] \`./gradlew test --tests com.surrealdb.BooleanOptionalTests\` — all 6 pass
- [x] \`./gradlew test\` — 269/270 pass; the one failure is \`ConnectionTests.connectWebsocket\` which requires a live SurrealDB server at \`ws://localhost:8000\` and is unrelated to this change
- [ ] User's original snippet from the bug report runs cleanly without the \`obj.success == null\` workaround