### PR TITLE
Support Java records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Support Java `record` classes in `create` and `select` (JDK 16+ at runtime). Records are hydrated via their canonical constructor; POJO behaviour on JDK 8+ is unchanged.
+
 ## [2.0.2] - 2026-05-20
 - Add Java query binding overloads and transaction bindings [#148](https://github.com/surrealdb/surrealdb.java/pull/148).
 - Enforce spotless/cargo fmt on PRs and scope GITHUB_TOKEN permissions [#150](https://github.com/surrealdb/surrealdb.java/pull/150).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ View the SDK documentation [here](https://surrealdb.com/docs/integration/librari
 - Simple API: [see docs](https://surrealdb.com/docs/integration/libraries/java).
 - Support of 'memory' (embedded SurrealDB).
 - Support of remote connection to SurrealDB.
+- Mutable POJOs (Java 8+) and immutable `record` classes (JDK 16+) for `create` / `select`.
 - Supported on JAVA JDK 8, 11, 17, 21, 25.
 - Supported architectures:
     - Linux (ARM) aarch64

--- a/build.gradle
+++ b/build.gradle
@@ -65,11 +65,24 @@ sourceSets {
     integrationTest {
         java
     }
+    // Java-record-using tests live in their own source set so the main library
+    // and the standard test suite remain compilable with --release 8.
+    // The set is always created (so configuration-time references resolve);
+    // compilation and execution are conditional on JDK 16+ below.
+    recordTest {
+        java {
+            srcDirs 'src/recordTest/java'
+        }
+        compileClasspath += sourceSets.main.output + sourceSets.test.output
+        runtimeClasspath += sourceSets.main.output + sourceSets.test.output
+    }
 }
 
 configurations {
     integrationTestImplementation.extendsFrom testImplementation
     integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+    recordTestImplementation.extendsFrom testImplementation
+    recordTestRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
 ext.nativeJar = file("native/surrealdb-${version}.jar")
@@ -189,6 +202,46 @@ test {
         showStackTraces = true
         exceptionFormat = "full"
     }
+}
+
+// Records require JDK 16+ at compile time. Only wire up the recordTest task graph
+// when the build JDK supports them; on older JDKs the source set is created but
+// its compile/test tasks are disabled, so JDK 8/11 builds remain green.
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+    tasks.named('compileRecordTestJava') {
+        options.release = 16
+    }
+
+    tasks.register('recordTest', Test) {
+        description = 'Runs the Java-record tests (requires JDK 16+).'
+        group = 'verification'
+        useJUnitPlatform()
+        dependsOn cargoBuild
+        testClassesDirs = sourceSets.recordTest.output.classesDirs
+        classpath = sourceSets.recordTest.runtimeClasspath
+        def nativeLibFile = file("target/debug/${nativeLibName}")
+        def nativeLibPath = nativeLibFile.absolutePath
+        systemProperty 'surrealdb.native.path', nativeLibPath
+        jvmArgs "-Dsurrealdb.native.path=${nativeLibPath}"
+        def debugDir = new File(projectDir, 'target/debug').absolutePath
+        def releaseDir = new File(projectDir, 'target/release').absolutePath
+        def libPath = debugDir + File.pathSeparator + releaseDir
+        systemProperty 'java.library.path', libPath
+        jvmArgs "-Djava.library.path=${libPath}"
+        systemProperty 'junit.jupiter.execution.timeout.default', '15s'
+        maxParallelForks = 1
+        testLogging {
+            events "passed", "failed", "skipped"
+            showStackTraces = true
+            exceptionFormat = "full"
+        }
+    }
+
+    tasks.named('check') { dependsOn 'recordTest' }
+} else {
+    // Disable the auto-generated tasks for the recordTest source set on older JDKs.
+    tasks.named('compileRecordTestJava') { enabled = false }
+    tasks.matching { it.name == 'processRecordTestResources' }.configureEach { enabled = false }
 }
 
 jacocoTestReport {

--- a/src/main/java/com/surrealdb/ValueClassConverter.java
+++ b/src/main/java/com/surrealdb/ValueClassConverter.java
@@ -1,6 +1,8 @@
 package com.surrealdb;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -12,10 +14,54 @@ import java.util.Optional;
 
 class ValueClassConverter<T> {
 
+	// Reflective access to record APIs (JDK 16+), looked up once.
+	// The library is compiled with --release 8, so we cannot reference
+	// Class.isRecord(),
+	// Class.getRecordComponents() or java.lang.reflect.RecordComponent directly.
+	private static final Method IS_RECORD;
+	private static final Method GET_RECORD_COMPONENTS;
+	private static final Method RC_GET_NAME;
+	private static final Method RC_GET_TYPE;
+	private static final Method RC_GET_GENERIC_TYPE;
+
+	static {
+		Method isRecord = null;
+		Method getRecordComponents = null;
+		Method rcGetName = null;
+		Method rcGetType = null;
+		Method rcGetGenericType = null;
+		try {
+			isRecord = Class.class.getMethod("isRecord");
+			getRecordComponents = Class.class.getMethod("getRecordComponents");
+			final Class<?> rcClass = Class.forName("java.lang.reflect.RecordComponent");
+			rcGetName = rcClass.getMethod("getName");
+			rcGetType = rcClass.getMethod("getType");
+			rcGetGenericType = rcClass.getMethod("getGenericType");
+		} catch (ReflectiveOperationException ignored) {
+			// Pre-16 JVM: leave everything null and fall through to the POJO path.
+		}
+		IS_RECORD = isRecord;
+		GET_RECORD_COMPONENTS = getRecordComponents;
+		RC_GET_NAME = rcGetName;
+		RC_GET_TYPE = rcGetType;
+		RC_GET_GENERIC_TYPE = rcGetGenericType;
+	}
+
 	private final Class<T> clazz;
 
 	ValueClassConverter(Class<T> clazz) {
 		this.clazz = clazz;
+	}
+
+	private static boolean isRecord(Class<?> clazz) {
+		if (IS_RECORD == null) {
+			return false;
+		}
+		try {
+			return (Boolean) IS_RECORD.invoke(clazz);
+		} catch (ReflectiveOperationException e) {
+			return false;
+		}
 	}
 
 	private static java.lang.Object convertSingleValue(final Value value) {
@@ -46,85 +92,167 @@ class ValueClassConverter<T> {
 		throw new SurrealException("Unsupported value: " + value);
 	}
 
-	private static <T> void setSingleValue(final Field field, final Class<?> type, final T target, final Value value)
-			throws IllegalAccessException {
+	// Type-aware single-value conversion: returns the boxed Java object that
+	// Field.set / Constructor.newInstance will auto-unbox into the target slot.
+	private static java.lang.Object convertSingleValueTyped(final Value value, final Class<?> type) {
 		if (value.isNull()) {
-			field.set(target, null);
-		} else if (value.isBoolean()) {
-			final boolean b = value.getBoolean();
-			if (type == Boolean.TYPE)
-				field.setBoolean(target, b);
-			else
-				field.set(target, b);
-		} else if (value.isDouble()) {
-			final double d = value.getDouble();
-			if (type == Double.TYPE)
-				field.setDouble(target, d);
-			else if (type == Float.TYPE)
-				field.setFloat(target, (float) d);
-			else if (type == Float.class)
-				field.set(target, (float) d);
-			else
-				field.set(target, d);
-		} else if (value.isLong()) {
-			final long l = value.getLong();
-			if (type == Long.TYPE)
-				field.setLong(target, l);
-			else if (type == Integer.TYPE)
-				field.setInt(target, (int) l);
-			else if (type == Integer.class)
-				field.set(target, (int) l);
-			else if (type == Short.TYPE)
-				field.setShort(target, (short) l);
-			else if (type == Short.class)
-				field.set(target, (short) l);
-			else
-				field.set(target, l);
-		} else if (value.isString()) {
-			field.set(target, value.getString());
-		} else if (value.isRecordId()) {
-			if (field.getType() == Id.class) {
-				field.set(target, value.getRecordId().getId());
-			} else {
-				field.set(target, value.getRecordId());
-			}
-		} else if (value.isGeometry()) {
-			field.set(target, value.getGeometry());
-		} else if (value.isBigDecimal()) {
-			field.set(target, value.getBigDecimal());
-		} else if (value.isBytes()) {
-			field.set(target, value.getBytes());
-		} else if (value.isUuid()) {
-			field.set(target, value.getUuid());
-		} else if (value.isDuration()) {
-			field.set(target, value.getDuration());
-		} else if (value.isDateTime()) {
-			field.set(target, value.getDateTime());
-		} else {
-			throw new SurrealException("Unsupported value: " + value);
+			return null;
 		}
+		if (value.isDouble()) {
+			final double d = value.getDouble();
+			if (type == Float.TYPE || type == Float.class) {
+				return (float) d;
+			}
+			return d;
+		}
+		if (value.isLong()) {
+			final long l = value.getLong();
+			if (type == Integer.TYPE || type == Integer.class) {
+				return (int) l;
+			}
+			if (type == Short.TYPE || type == Short.class) {
+				return (short) l;
+			}
+			return l;
+		}
+		if (value.isRecordId()) {
+			if (type == Id.class) {
+				return value.getRecordId().getId();
+			}
+			return value.getRecordId();
+		}
+		return convertSingleValue(value);
 	}
 
-	private static java.lang.Object convertArrayValue(final Field field, final Value value)
+	// Convert a Value into the Java object suitable for the given declared type.
+	// Used by both the POJO field-setting path and the record canonical-constructor
+	// path.
+	private static java.lang.Object convertValueToType(final Value value, final Class<?> type, final Type genericType)
 			throws ReflectiveOperationException {
-		if (value.isObject()) {
-			final Class<?> subType = getGenericType(field, 0);
-			if (subType == null) {
-				throw new SurrealException("Unsupported field type: " + field);
-			}
-			return convert(subType, value.getObject());
-		} else if (value.isArray()) {
-			final List<java.lang.Object> arrayList = new ArrayList<>();
-			for (final Value elementValue : value.getArray()) {
-				arrayList.add(convertArrayValue(field, elementValue));
-			}
-			return arrayList;
-		} else {
-			return convertSingleValue(value);
+		if (Value.class.equals(type)) {
+			return value;
 		}
+		if (value.isArray()) {
+			final Class<?> elementType = firstTypeArgumentRaw(genericType);
+			final Type elementGenericType = firstTypeArgument(genericType);
+			final List<java.lang.Object> list = new ArrayList<>();
+			for (final Value element : value.getArray()) {
+				list.add(convertArrayElement(element, elementType, elementGenericType));
+			}
+			if (type == byte[].class) {
+				final byte[] bytes = new byte[list.size()];
+				for (int i = 0; i < list.size(); i++) {
+					final java.lang.Object e = list.get(i);
+					if (e instanceof Number) {
+						bytes[i] = ((Number) e).byteValue();
+					} else {
+						throw new SurrealException(
+								"Cannot convert " + (e == null ? "null" : e.getClass()) + " to byte");
+					}
+				}
+				return bytes;
+			}
+			if (Optional.class.equals(type)) {
+				return Optional.of(list);
+			}
+			return list;
+		}
+		if (value.isObject()) {
+			if (Map.class.isAssignableFrom(type)) {
+				final Class<?> valueType = secondTypeArgumentRaw(genericType);
+				if (valueType == null) {
+					throw new SurrealException("Unsupported map type for: " + genericType);
+				}
+				final Map<String, java.lang.Object> map = new HashMap<>();
+				for (final Entry mapEntry : value.getObject()) {
+					final String entryKey = mapEntry.getKey();
+					final Value entryValue = mapEntry.getValue();
+					// todo - array support inside maps
+					if (entryValue.isObject()) {
+						map.put(entryKey, convert(valueType, entryValue.getObject()));
+					} else {
+						map.put(entryKey, convertSingleValue(entryValue));
+					}
+				}
+				return map;
+			}
+			if (Optional.class.equals(type)) {
+				final Class<?> innerType = firstTypeArgumentRaw(genericType);
+				if (innerType == null) {
+					throw new SurrealException("Unsupported Optional type for: " + genericType);
+				}
+				return Optional.of(convert(innerType, value.getObject()));
+			}
+			return convert(type, value.getObject());
+		}
+		// scalar value
+		if (Optional.class.equals(type)) {
+			final java.lang.Object converted = convertSingleValue(value);
+			return converted == null ? Optional.empty() : Optional.of(converted);
+		}
+		return convertSingleValueTyped(value, type);
+	}
+
+	private static java.lang.Object convertArrayElement(final Value value, final Class<?> elementType,
+			final Type elementGenericType) throws ReflectiveOperationException {
+		if (value.isObject()) {
+			if (elementType == null) {
+				throw new SurrealException("Unsupported element type for array");
+			}
+			return convert(elementType, value.getObject());
+		}
+		if (value.isArray()) {
+			final List<java.lang.Object> nested = new ArrayList<>();
+			for (final Value v : value.getArray()) {
+				nested.add(convertArrayElement(v, elementType, elementGenericType));
+			}
+			return nested;
+		}
+		// Preserve the historical behaviour: scalar array elements are type-agnostic.
+		return convertSingleValue(value);
+	}
+
+	private static Type firstTypeArgument(final Type genericType) {
+		if (genericType instanceof ParameterizedType) {
+			final Type[] args = ((ParameterizedType) genericType).getActualTypeArguments();
+			if (args.length > 0) {
+				return args[0];
+			}
+		}
+		return null;
+	}
+
+	private static Class<?> firstTypeArgumentRaw(final Type genericType) {
+		return rawType(firstTypeArgument(genericType));
+	}
+
+	private static Class<?> secondTypeArgumentRaw(final Type genericType) {
+		if (genericType instanceof ParameterizedType) {
+			final Type[] args = ((ParameterizedType) genericType).getActualTypeArguments();
+			if (args.length > 1) {
+				return rawType(args[1]);
+			}
+		}
+		return null;
+	}
+
+	private static Class<?> rawType(final Type type) {
+		if (type instanceof Class) {
+			return (Class<?>) type;
+		}
+		if (type instanceof ParameterizedType) {
+			final Type raw = ((ParameterizedType) type).getRawType();
+			if (raw instanceof Class) {
+				return (Class<?>) raw;
+			}
+		}
+		return null;
 	}
 
 	private static <T> T convert(Class<T> clazz, Object source) throws ReflectiveOperationException {
+		if (isRecord(clazz)) {
+			return convertRecord(clazz, source);
+		}
 		final T target = clazz.getConstructor().newInstance();
 		initOptionalFields(clazz, target);
 		for (final Entry entry : source) {
@@ -132,84 +260,88 @@ class ValueClassConverter<T> {
 				final String key = entry.getKey();
 				final Value value = entry.getValue();
 				final Field field = getInheritedDeclaredField(clazz, key);
-				final Class<?> type = field.getType();
-
 				field.setAccessible(true);
-
-				if (Value.class.equals(type)) {
-					field.set(target, value);
-				} else if (value.isArray()) {
-					final List<java.lang.Object> arrayList = new ArrayList<>();
-					for (final Value elementValue : value.getArray()) {
-						arrayList.add(convertArrayValue(field, elementValue));
-					}
-					setFieldObject(field, type, target, arrayList);
-				} else if (value.isObject()) {
-					if (Map.class.isAssignableFrom(type)) {
-						final Map<String, java.lang.Object> map = new HashMap<>();
-						final Class<?> subType = getGenericType(field, 1);
-						if (subType == null) {
-							throw new SurrealException("Unsupported field type: " + field);
-						}
-						for (final Entry mapEntry : value.getObject()) {
-							final String entryKey = mapEntry.getKey();
-							final Value entryValue = mapEntry.getValue();
-							// todo - array support
-							if (entryValue.isObject()) {
-								map.put(entryKey, convert(subType, entryValue.getObject()));
-							} else {
-								map.put(entryKey, convertSingleValue(entryValue));
-							}
-						}
-						setFieldObject(field, type, target, map);
-					} else {
-						java.lang.Object o = convert(type, value.getObject());
-						setFieldObject(field, type, target, o);
-					}
-				} else {
-					setFieldSingleValue(field, type, target, value);
+				final java.lang.Object converted = convertValueToType(value, field.getType(), field.getGenericType());
+				if (converted == null && field.getType().isPrimitive()) {
+					// Leave primitive fields at their default value; setting null would throw.
+					continue;
 				}
+				field.set(target, converted);
 			} catch (NoSuchFieldException e) {
-				// Safe to ignore
+				// Safe to ignore: source has a key with no matching field.
 			}
 		}
 		return target;
 	}
 
-	private static <T, V> void setFieldObject(Field field, Class<?> type, T target, V value)
-			throws ReflectiveOperationException {
-		if (Optional.class.equals(type)) {
-			field.set(target, Optional.of(value));
-		} else if (type == byte[].class && value instanceof List) {
-			// Special handling for byte[] fields
-			final List<?> list = (List<?>) value;
-			final byte[] bytes = new byte[list.size()];
-			for (int i = 0; i < list.size(); i++) {
-				final java.lang.Object element = list.get(i);
-				if (element instanceof Number) {
-					bytes[i] = ((Number) element).byteValue();
-				} else {
-					throw new SurrealException("Cannot convert " + element.getClass() + " to byte");
-				}
-			}
-			field.set(target, bytes);
-		} else {
-			field.set(target, value);
+	private static <T> T convertRecord(final Class<T> clazz, final Object source) throws ReflectiveOperationException {
+		if (GET_RECORD_COMPONENTS == null) {
+			// Should be unreachable: isRecord() returned true, so the JVM exposes
+			// RecordComponent.
+			throw new SurrealException("Record reflection APIs unavailable for " + clazz.getName());
 		}
+		final java.lang.Object[] componentsArray = (java.lang.Object[]) GET_RECORD_COMPONENTS.invoke(clazz);
+		final int count = componentsArray.length;
+		final String[] names = new String[count];
+		final Class<?>[] types = new Class<?>[count];
+		final Type[] genericTypes = new Type[count];
+		for (int i = 0; i < count; i++) {
+			final java.lang.Object rc = componentsArray[i];
+			names[i] = (String) RC_GET_NAME.invoke(rc);
+			types[i] = (Class<?>) RC_GET_TYPE.invoke(rc);
+			genericTypes[i] = (Type) RC_GET_GENERIC_TYPE.invoke(rc);
+		}
+
+		// Build a lookup of incoming entries keyed by name.
+		final Map<String, Value> entries = new HashMap<>();
+		for (final Entry entry : source) {
+			entries.put(entry.getKey(), entry.getValue());
+		}
+
+		final java.lang.Object[] args = new java.lang.Object[count];
+		for (int i = 0; i < count; i++) {
+			final Value value = entries.get(names[i]);
+			final Class<?> type = types[i];
+			if (value == null) {
+				args[i] = defaultForRecordComponent(type);
+				continue;
+			}
+			final java.lang.Object converted = convertValueToType(value, type, genericTypes[i]);
+			if (converted == null) {
+				args[i] = defaultForRecordComponent(type);
+			} else {
+				args[i] = converted;
+			}
+		}
+
+		final Constructor<T> ctor = clazz.getDeclaredConstructor(types);
+		ctor.setAccessible(true);
+		return ctor.newInstance(args);
 	}
 
-	private static <T, V> void setFieldSingleValue(Field field, Class<?> type, T target, Value value)
-			throws ReflectiveOperationException {
+	private static java.lang.Object defaultForRecordComponent(final Class<?> type) {
 		if (Optional.class.equals(type)) {
-			final java.lang.Object converted = convertSingleValue(value);
-			if (converted == null) {
-				field.set(target, Optional.empty());
-			} else {
-				field.set(target, Optional.of(converted));
-			}
-		} else {
-			setSingleValue(field, type, target, value);
+			return Optional.empty();
 		}
+		if (type.isPrimitive()) {
+			if (type == Boolean.TYPE)
+				return Boolean.FALSE;
+			if (type == Byte.TYPE)
+				return (byte) 0;
+			if (type == Short.TYPE)
+				return (short) 0;
+			if (type == Integer.TYPE)
+				return 0;
+			if (type == Long.TYPE)
+				return 0L;
+			if (type == Float.TYPE)
+				return 0f;
+			if (type == Double.TYPE)
+				return 0d;
+			if (type == Character.TYPE)
+				return (char) 0;
+		}
+		return null;
 	}
 
 	private static <T> void initOptionalFields(Class<?> clazz, T target) throws IllegalAccessException {
@@ -229,22 +361,6 @@ class ValueClassConverter<T> {
 			}
 			c = c.getSuperclass();
 		}
-	}
-
-	static Class<?> getGenericType(final Field field, final int index) {
-		// Check if the field is parameterized
-		if (field.getGenericType() instanceof ParameterizedType) {
-			ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
-
-			// Get the actual type arguments (generics)
-			final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
-
-			if (actualTypeArguments.length > index) {
-				// Return the first type argument
-				return (Class<?>) actualTypeArguments[index];
-			}
-		}
-		return null;
 	}
 
 	static Field getInheritedDeclaredField(Class<?> clazz, String fieldName) throws NoSuchFieldException {

--- a/src/main/java/com/surrealdb/ValueClassConverter.java
+++ b/src/main/java/com/surrealdb/ValueClassConverter.java
@@ -187,7 +187,10 @@ class ValueClassConverter<T> {
 		}
 		// scalar value
 		if (Optional.class.equals(type)) {
-			final java.lang.Object converted = convertSingleValue(value);
+			final Class<?> innerType = firstTypeArgumentRaw(genericType);
+			final java.lang.Object converted = innerType == null
+					? convertSingleValue(value)
+					: convertSingleValueTyped(value, innerType);
 			return converted == null ? Optional.empty() : Optional.of(converted);
 		}
 		return convertSingleValueTyped(value, type);

--- a/src/recordTest/java/com/surrealdb/RecordCrudTests.java
+++ b/src/recordTest/java/com/surrealdb/RecordCrudTests.java
@@ -1,0 +1,99 @@
+package com.surrealdb;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static com.surrealdb.RecordHelpers.JAIME;
+import static com.surrealdb.RecordHelpers.TOBIE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import com.surrealdb.pojos.PersonRecord;
+
+public class RecordCrudTests {
+
+	@Test
+	void insertRecordObject() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final PersonRecord inserted = surreal.insert(PersonRecord.class, "person", JAIME).get(0);
+			assertNotNull(inserted.id());
+			assertEquals(JAIME.name(), inserted.name());
+			assertEquals(JAIME.tags(), inserted.tags());
+			assertEquals(JAIME.category(), inserted.category());
+			assertEquals(JAIME.emails(), inserted.emails());
+		}
+	}
+
+	@Test
+	void insertRecordObjects() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final List<PersonRecord> inserted = surreal.insert(PersonRecord.class, "person", TOBIE, JAIME);
+			assertEquals(2, inserted.size());
+			assertEquals(TOBIE.name(), inserted.get(0).name());
+			assertEquals(JAIME.name(), inserted.get(1).name());
+		}
+	}
+
+	@Test
+	void updateRecordIdObject() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final RecordId id = new RecordId("person", 1);
+			surreal.create(PersonRecord.class, id, TOBIE);
+			final PersonRecord updated = surreal.update(PersonRecord.class, id, UpType.CONTENT, JAIME);
+			assertEquals(JAIME.name(), updated.name());
+			assertEquals(JAIME.category(), updated.category());
+			assertEquals(JAIME.nickname(), updated.nickname());
+		}
+	}
+
+	@Test
+	void updateRecordTableObjects() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			surreal.create(PersonRecord.class, new RecordId("person", 1), TOBIE);
+			surreal.create(PersonRecord.class, new RecordId("person", 2), TOBIE);
+			final Iterator<PersonRecord> updated = surreal.update(PersonRecord.class, "person", UpType.CONTENT, JAIME);
+			int count = 0;
+			while (updated.hasNext()) {
+				assertEquals(JAIME.name(), updated.next().name());
+				count++;
+			}
+			assertEquals(2, count);
+		}
+	}
+
+	@Test
+	void upsertRecordIdObject() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final RecordId id = new RecordId("person", 1);
+			// No pre-existing row: upsert acts as create.
+			final PersonRecord upserted = surreal.upsert(PersonRecord.class, id, UpType.CONTENT, JAIME);
+			assertEquals(JAIME.name(), upserted.name());
+			assertEquals(JAIME.nickname(), upserted.nickname());
+		}
+	}
+
+	@Test
+	void upsertRecordTableObjects() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			surreal.create(PersonRecord.class, new RecordId("person", 1), TOBIE);
+			surreal.create(PersonRecord.class, new RecordId("person", 2), TOBIE);
+			final Iterator<PersonRecord> upserted = surreal.upsert(PersonRecord.class, "person", UpType.CONTENT, JAIME);
+			// Mirrors the POJO suite: assert each returned row matches without pinning
+			// the row count, since upsert-on-table semantics differ from update-on-table.
+			boolean any = false;
+			while (upserted.hasNext()) {
+				assertEquals(JAIME.name(), upserted.next().name());
+				any = true;
+			}
+			assertTrue(any);
+		}
+	}
+}

--- a/src/recordTest/java/com/surrealdb/RecordHelpers.java
+++ b/src/recordTest/java/com/surrealdb/RecordHelpers.java
@@ -1,0 +1,27 @@
+package com.surrealdb;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import com.surrealdb.pojos.EmailRecord;
+import com.surrealdb.pojos.NameRecord;
+import com.surrealdb.pojos.PersonRecord;
+
+final class RecordHelpers {
+
+	static final PersonRecord TOBIE = new PersonRecord(null, "Tobie", Arrays.asList("CEO", "CTO"), 1L, true,
+			Collections.singletonList(new EmailRecord("tobie@example.com", new NameRecord("Tobie", "Foo"))),
+			Optional.of("toby"));
+
+	static final PersonRecord JAIME = new PersonRecord(null, "Jaime", Collections.singletonList("COO"), 2L, true,
+			Collections.singletonList(new EmailRecord("jaime@example.com", new NameRecord("Jaime", "Bar"))),
+			Optional.empty());
+
+	static PersonRecord withoutId(PersonRecord p) {
+		return new PersonRecord(null, p.name(), p.tags(), p.category(), p.active(), p.emails(), p.nickname());
+	}
+
+	private RecordHelpers() {
+	}
+}

--- a/src/recordTest/java/com/surrealdb/RecordRoundTripTests.java
+++ b/src/recordTest/java/com/surrealdb/RecordRoundTripTests.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import com.surrealdb.pojos.PersonRecord;
+import com.surrealdb.pojos.TypedOptionalRecord;
 
 public class RecordRoundTripTests {
 
@@ -78,6 +79,39 @@ public class RecordRoundTripTests {
 
 			final PersonRecord createdJaime = surreal.create(PersonRecord.class, "person", JAIME).get(0);
 			assertEquals(Optional.empty(), createdJaime.nickname());
+		}
+	}
+
+	@Test
+	void typedOptionalScalarsHydrateWithDeclaredType() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final TypedOptionalRecord input = new TypedOptionalRecord(Optional.of(42), Optional.of(3.14f),
+					Optional.of((short) 7), Optional.of(99L));
+			final TypedOptionalRecord readBack = surreal.create(TypedOptionalRecord.class, "tops", input).get(0);
+
+			// instanceof checks pin the boxed runtime type — without the typed
+			// Optional conversion fix, intOpt/floatOpt/shortOpt come back as
+			// Long/Double/Long, and the auto-unboxing assignments below would CCE.
+			assertTrue(readBack.intOpt().isPresent());
+			assertTrue(readBack.intOpt().get() instanceof Integer);
+			final int unboxedInt = readBack.intOpt().get();
+			assertEquals(42, unboxedInt);
+
+			assertTrue(readBack.floatOpt().isPresent());
+			assertTrue(readBack.floatOpt().get() instanceof Float);
+			final float unboxedFloat = readBack.floatOpt().get();
+			assertEquals(3.14f, unboxedFloat, 0.001f);
+
+			assertTrue(readBack.shortOpt().isPresent());
+			assertTrue(readBack.shortOpt().get() instanceof Short);
+			final short unboxedShort = readBack.shortOpt().get();
+			assertEquals((short) 7, unboxedShort);
+
+			assertTrue(readBack.longOpt().isPresent());
+			assertTrue(readBack.longOpt().get() instanceof Long);
+			final long unboxedLong = readBack.longOpt().get();
+			assertEquals(99L, unboxedLong);
 		}
 	}
 

--- a/src/recordTest/java/com/surrealdb/RecordRoundTripTests.java
+++ b/src/recordTest/java/com/surrealdb/RecordRoundTripTests.java
@@ -1,0 +1,116 @@
+package com.surrealdb;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import com.surrealdb.pojos.EmailRecord;
+import com.surrealdb.pojos.NameRecord;
+import com.surrealdb.pojos.PersonRecord;
+
+public class RecordRoundTripTests {
+
+	private static final PersonRecord TOBIE = new PersonRecord(null, "Tobie", Arrays.asList("CEO", "CTO"), 1L, true,
+			Collections.singletonList(new EmailRecord("tobie@example.com", new NameRecord("Tobie", "Foo"))),
+			Optional.of("toby"));
+
+	private static final PersonRecord JAIME = new PersonRecord(null, "Jaime", Collections.singletonList("COO"), 2L,
+			true, Collections.singletonList(new EmailRecord("jaime@example.com", new NameRecord("Jaime", "Bar"))),
+			Optional.empty());
+
+	private static <T> List<T> drain(Iterator<T> iterator) {
+		final Iterable<T> iterable = () -> iterator;
+		final Stream<T> stream = StreamSupport.stream(iterable.spliterator(), false);
+		return stream.collect(Collectors.toList());
+	}
+
+	// Records have final fields so we can't null out `id` like the POJO tests do.
+	// Compare records by erasing the id from the read-back instance.
+	private static PersonRecord withoutId(PersonRecord p) {
+		return new PersonRecord(null, p.name(), p.tags(), p.category(), p.active(), p.emails(), p.nickname());
+	}
+
+	@Test
+	void createAndSelectViaRecordId() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final PersonRecord created = surreal.create(PersonRecord.class, "person", TOBIE).get(0);
+			assertNotNull(created.id());
+			final Optional<PersonRecord> readBack = surreal.select(PersonRecord.class, created.id());
+			assertTrue(readBack.isPresent());
+			assertEquals(created.name(), readBack.get().name());
+			assertEquals(TOBIE.tags(), readBack.get().tags());
+			assertEquals(TOBIE.category(), readBack.get().category());
+			assertEquals(TOBIE.active(), readBack.get().active());
+			assertEquals(TOBIE.emails(), readBack.get().emails());
+			assertEquals(TOBIE.nickname(), readBack.get().nickname());
+		}
+	}
+
+	@Test
+	void selectListedRecordIds() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final List<PersonRecord> created = surreal.create(PersonRecord.class, "person", TOBIE, JAIME);
+			final List<PersonRecord> selected = surreal.select(PersonRecord.class, created.get(0).id(),
+					created.get(1).id());
+			assertEquals(2, selected.size());
+			assertEquals(TOBIE.name(), selected.get(0).name());
+			assertEquals(JAIME.name(), selected.get(1).name());
+		}
+	}
+
+	@Test
+	void selectTableViaIterator() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			surreal.create(PersonRecord.class, "person", TOBIE, JAIME);
+			final Iterator<PersonRecord> iterator = surreal.select(PersonRecord.class, "person");
+			final List<PersonRecord> people = drain(iterator);
+			assertEquals(2, people.size());
+			final List<PersonRecord> normalised = people.stream().map(RecordRoundTripTests::withoutId)
+					.collect(Collectors.toList());
+			assertTrue(normalised.contains(TOBIE));
+			assertTrue(normalised.contains(JAIME));
+		}
+	}
+
+	@Test
+	void optionalComponentPresentAndAbsent() {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final PersonRecord created = surreal.create(PersonRecord.class, "person", TOBIE).get(0);
+			assertEquals(Optional.of("toby"), created.nickname());
+
+			final PersonRecord createdJaime = surreal.create(PersonRecord.class, "person", JAIME).get(0);
+			assertEquals(Optional.empty(), createdJaime.nickname());
+		}
+	}
+
+	@Test
+	void minimalRecordMatchesUserReproducer() {
+		// The reproducer from the user: a small record with two String components.
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("my_ns").useDb("my_db");
+			surreal.create("record", new MyRecord("foo", "myTenant"));
+			final Iterator<MyRecord> iterator = surreal.select(MyRecord.class, "record");
+			final List<MyRecord> rows = drain(iterator);
+			assertEquals(1, rows.size());
+			assertEquals("foo", rows.get(0).name());
+			assertEquals("myTenant", rows.get(0).tenant());
+		}
+	}
+
+	public record MyRecord(String name, String tenant) {
+	}
+}

--- a/src/recordTest/java/com/surrealdb/RecordRoundTripTests.java
+++ b/src/recordTest/java/com/surrealdb/RecordRoundTripTests.java
@@ -1,7 +1,5 @@
 package com.surrealdb;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -9,35 +7,21 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static com.surrealdb.RecordHelpers.JAIME;
+import static com.surrealdb.RecordHelpers.TOBIE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
-import com.surrealdb.pojos.EmailRecord;
-import com.surrealdb.pojos.NameRecord;
 import com.surrealdb.pojos.PersonRecord;
 
 public class RecordRoundTripTests {
-
-	private static final PersonRecord TOBIE = new PersonRecord(null, "Tobie", Arrays.asList("CEO", "CTO"), 1L, true,
-			Collections.singletonList(new EmailRecord("tobie@example.com", new NameRecord("Tobie", "Foo"))),
-			Optional.of("toby"));
-
-	private static final PersonRecord JAIME = new PersonRecord(null, "Jaime", Collections.singletonList("COO"), 2L,
-			true, Collections.singletonList(new EmailRecord("jaime@example.com", new NameRecord("Jaime", "Bar"))),
-			Optional.empty());
 
 	private static <T> List<T> drain(Iterator<T> iterator) {
 		final Iterable<T> iterable = () -> iterator;
 		final Stream<T> stream = StreamSupport.stream(iterable.spliterator(), false);
 		return stream.collect(Collectors.toList());
-	}
-
-	// Records have final fields so we can't null out `id` like the POJO tests do.
-	// Compare records by erasing the id from the read-back instance.
-	private static PersonRecord withoutId(PersonRecord p) {
-		return new PersonRecord(null, p.name(), p.tags(), p.category(), p.active(), p.emails(), p.nickname());
 	}
 
 	@Test
@@ -78,7 +62,7 @@ public class RecordRoundTripTests {
 			final Iterator<PersonRecord> iterator = surreal.select(PersonRecord.class, "person");
 			final List<PersonRecord> people = drain(iterator);
 			assertEquals(2, people.size());
-			final List<PersonRecord> normalised = people.stream().map(RecordRoundTripTests::withoutId)
+			final List<PersonRecord> normalised = people.stream().map(RecordHelpers::withoutId)
 					.collect(Collectors.toList());
 			assertTrue(normalised.contains(TOBIE));
 			assertTrue(normalised.contains(JAIME));

--- a/src/recordTest/java/com/surrealdb/pojos/EmailRecord.java
+++ b/src/recordTest/java/com/surrealdb/pojos/EmailRecord.java
@@ -1,0 +1,4 @@
+package com.surrealdb.pojos;
+
+public record EmailRecord(String address, NameRecord name) {
+}

--- a/src/recordTest/java/com/surrealdb/pojos/NameRecord.java
+++ b/src/recordTest/java/com/surrealdb/pojos/NameRecord.java
@@ -1,0 +1,4 @@
+package com.surrealdb.pojos;
+
+public record NameRecord(String first, String last) {
+}

--- a/src/recordTest/java/com/surrealdb/pojos/PersonRecord.java
+++ b/src/recordTest/java/com/surrealdb/pojos/PersonRecord.java
@@ -1,0 +1,10 @@
+package com.surrealdb.pojos;
+
+import com.surrealdb.RecordId;
+
+import java.util.List;
+import java.util.Optional;
+
+public record PersonRecord(RecordId id, String name, List<String> tags, long category, boolean active,
+		List<EmailRecord> emails, Optional<String> nickname) {
+}

--- a/src/recordTest/java/com/surrealdb/pojos/TypedOptionalRecord.java
+++ b/src/recordTest/java/com/surrealdb/pojos/TypedOptionalRecord.java
@@ -1,0 +1,7 @@
+package com.surrealdb.pojos;
+
+import java.util.Optional;
+
+public record TypedOptionalRecord(Optional<Integer> intOpt, Optional<Float> floatOpt, Optional<Short> shortOpt,
+		Optional<Long> longOpt) {
+}


### PR DESCRIPTION
## Summary

- Adds Java `record` support to `ValueClassConverter` so `select(MyRecord.class, ...)` works as advertised. Records are hydrated through their canonical constructor.
- Refactors the POJO path through a shared `convertValueToType(Value, Class<?>, Type)` helper so the POJO and record paths share dispatch logic. Existing POJO behaviour is preserved.
- Detection of record classes is done reflectively (`Class.class.getMethod("isRecord")` etc.) so the library still compiles with `--release 8`; on a pre-16 JVM the probe sees no `isRecord()` and the existing POJO error path takes over.
- Records work transparently across **every** typed-result method (`create`, `select`, `insert`, `insertRelation`, `insertRelations`, `relate`, `update`, `upsert` and their `*Sync` variants) because they all route through either `Value.get(type)` or `ValueObjectIterator`, both of which use `ValueClassConverter`.
- Also fixes a latent type-coercion bug in the scalar `Optional` path that became more reachable once typed record components started flowing through the same helper: `Optional<Integer>`, `Optional<Short>`, `Optional<Float>`, `Optional<Id>` were being hydrated with `Long` / `Long` / `Double` / `RecordId` runtime types inside a raw `Optional`, throwing `ClassCastException` at use. The Optional inner type now drives `convertSingleValueTyped` so the boxed runtime type matches the declared component type.

## Why

`create(...)` already worked for records by accident — `ValueBuilder` reflects over `getDeclaredFields()` and records expose synthetic backing fields. `select(...)` failed at two distinct lines in `ValueClassConverter`:

- `clazz.getConstructor().newInstance()` — records have no no-arg constructor.
- `field.set(target, value)` — record fields are `final`; even if construction succeeded, post-construction mutation throws.

Reported via the minimal reproducer (`record MyRecordRecord(String name, String tenant)`), which is now covered by `RecordRoundTripTests.minimalRecordMatchesUserReproducer`.

## User-facing example

After this PR, the following works end-to-end on JDK 16+. Both `create` and `select` accept the record class directly.

```java
import com.surrealdb.Surreal;

public record MyRecord(String name, String tenant) {}

void main() {
    try (var surreal = new Surreal()) {
        surreal.connect("memory");
        surreal.useNs("my_ns").useDb("my_db");

        // Insert a record-typed instance
        surreal.create("record", new MyRecord("foo", "myTenant"));

        // Read it back, deserialising straight into the record
        var iterable = surreal.select(MyRecord.class, "record");
        while (iterable.hasNext()) {
            var rec = iterable.next();
            System.out.println("Name:   " + rec.name());
            System.out.println("Tenant: " + rec.tenant());
        }
    }
}
```

Richer record shapes — nested records, collections, `Optional<T>` components (including typed scalar optionals like `Optional<Integer>`), `RecordId` components — are also supported and exercised by the new test suite:

```java
import com.surrealdb.RecordId;
import java.util.List;
import java.util.Optional;

public record Email(String address, Name name) {}
public record Name(String first, String last) {}

public record Person(
        RecordId id,
        String name,
        List<String> tags,
        long category,
        boolean active,
        List<Email> emails,
        Optional<String> nickname,
        Optional<Integer> rank) {}

try (var surreal = new Surreal()) {
    surreal.connect("memory").useNs("test").useDb("test");

    var tobie = new Person(
            null,
            "Tobie",
            List.of("CEO", "CTO"),
            1L,
            true,
            List.of(new Email("tobie@example.com", new Name("Tobie", "Foo"))),
            Optional.of("toby"),
            Optional.of(42));

    Person created = surreal.create(Person.class, "person", tobie).get(0);
    Person readBack = surreal.select(Person.class, created.id()).orElseThrow();
    int rank = readBack.rank().orElse(0); // Optional<Integer>.get() returns Integer
}
```

Missing fields in the stored row map to sensible defaults: `Optional<T>` components become `Optional.empty()`, primitive components become `0` / `false`, and reference components become `null`.

POJO usage is unchanged — existing `Person` POJO classes (no-arg constructor + mutable fields) continue to round-trip on every supported JDK (8+).

## What's in the PR

- `src/main/java/com/surrealdb/ValueClassConverter.java` — reflective record detection, new `convertRecord` path, `convertValueToType` helper shared with the POJO path, typed-Optional scalar fix.
- `build.gradle` — new `recordTest` source set compiled with `--release 16`, registered into `check` only on JDK 16+. Disabled on older JDKs.
- `src/recordTest/java/com/surrealdb/RecordRoundTripTests.java` — focused select/create coverage (incl. the user's minimal reproducer, `Optional<T>` and nested-record components, typed `Optional<Integer/Short/Float/Long>`).
- `src/recordTest/java/com/surrealdb/RecordCrudTests.java` — `insert` / `update` / `upsert` coverage across both single-id and table variants.
- `src/recordTest/java/com/surrealdb/RecordHelpers.java` — shared fixtures (`TOBIE`, `JAIME`, `withoutId`).
- `src/recordTest/java/com/surrealdb/pojos/{PersonRecord,EmailRecord,NameRecord,TypedOptionalRecord}.java` — record-typed test pojos.
- `README.md` — features bullet noting record support (JDK 16+).
- `CHANGELOG.md` — `[Unreleased]` entry.

## Compatibility

- Library still compiles with `--release 8` and minimum JDK 8 (as advertised).
- The reflective probe in `ValueClassConverter` falls through cleanly on pre-16 runtimes — record classes can't exist there anyway because the `record` keyword and the record bytecode attribute both require JDK 16+.
- The `recordTest` source set is only wired up when the build JDK is 16+, so JDK 8/11 CI lanes are untouched.

## Test plan

- [x] `./gradlew test` — existing suite still passes, including `BooleanOptionalTests` from #155 (verifying the typed-Optional fix did not regress `Optional<Boolean>` / `Optional<String>` behaviour), `SelectTests` 7/7, `CreateTests` 7/7, `UpdateTests`, `UpsertTests`, `InsertTests`. The only failure locally is `ConnectionTests.connectWebsocket`, which requires an external SurrealDB WebSocket server and is unrelated to this change.
- [x] `./gradlew recordTest` (on JDK 16+) — **12/12** record tests pass:
  - `RecordRoundTripTests` (6): single-id select, multi-id select, table iterator, `Optional<T>` present/absent, typed-`Optional<Integer/Short/Float/Long>` round-trip with `instanceof` runtime-type checks, the user's minimal reproducer.
  - `RecordCrudTests` (6): `insertRecordObject`, `insertRecordObjects`, `updateRecordIdObject`, `updateRecordTableObjects`, `upsertRecordIdObject`, `upsertRecordTableObjects` — covering both `value.get(type)` and `ValueObjectIterator` deserialisation paths.
- [x] `./gradlew spotlessCheck` — clean.
- [ ] CI matrix (JDK 8 / 11 / 17 / 21 / 25): `test` runs everywhere; `recordTest` runs on 17/21/25.

## Follow-up (not in this PR)

The marketing claim about records lives in `surrealdb/www.surrealdb.com` — worth a parallel docs PR there now that the SDK backs the claim.
