### PR TITLE
Auto-load native library on first use of any Native-backed POJO

### DIFF
--- a/src/main/java/com/surrealdb/LiveStream.java
+++ b/src/main/java/com/surrealdb/LiveStream.java
@@ -31,10 +31,6 @@ import java.util.Optional;
  */
 public class LiveStream implements AutoCloseable {
 
-	static {
-		Loader.loadNative();
-	}
-
 	/**
 	 * Pointer to the native {@code LiveStreamChannel}. Zeroed by {@link #close()}
 	 * after the native resources have been released. Declared {@code volatile} so

--- a/src/main/java/com/surrealdb/Loader.java
+++ b/src/main/java/com/surrealdb/Loader.java
@@ -91,7 +91,7 @@ class Loader {
 
 	private static File extract(String path) throws IOException {
 		final String TargetsPath = "natives/" + path + "/" + SURREALDB_LIBNAME;
-		final URL Targets = Surreal.class.getClassLoader().getResource(TargetsPath);
+		final URL Targets = Native.class.getClassLoader().getResource(TargetsPath);
 		if (Targets == null) {
 			throw new RuntimeException("Couldn't find Targets: " + TargetsPath);
 		}

--- a/src/main/java/com/surrealdb/Native.java
+++ b/src/main/java/com/surrealdb/Native.java
@@ -8,6 +8,10 @@ package com.surrealdb;
  */
 public abstract class Native {
 
+	static {
+		Loader.loadNative();
+	}
+
 	// Unique internal ptr used by the native library to locate the SurrealDB
 	// instance
 	private long ptr;

--- a/src/main/java/com/surrealdb/Surreal.java
+++ b/src/main/java/com/surrealdb/Surreal.java
@@ -26,10 +26,6 @@ import com.surrealdb.signin.Token;
  */
 public class Surreal extends Native implements AutoCloseable {
 
-	static {
-		Loader.loadNative();
-	}
-
 	// Current namespace and database set by useNs() / useDb() / useDefaults() (from
 	// server return value).
 	private String namespace;

--- a/src/test/java/com/surrealdb/PojoStandaloneTests.java
+++ b/src/test/java/com/surrealdb/PojoStandaloneTests.java
@@ -1,0 +1,94 @@
+// DO NOT import com.surrealdb.Surreal or com.surrealdb.LiveStream from this
+// file. These tests assert that publicly-constructible Native-backed POJOs
+// (RecordId, Id, Array) auto-load the native library by themselves, without
+// any prior reference to Surreal/LiveStream. Touching those classes here
+// would silently mask the bug under test by loading the library through
+// their (no-longer-present) static initializers.
+package com.surrealdb;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the contract that instantiating a Surreal POJO does not
+ * require a running {@code Surreal} instance. The native library must load
+ * transparently the first time any {@code Native} subclass is touched.
+ */
+public class PojoStandaloneTests {
+
+	@Test
+	void recordIdWithStringKey() {
+		RecordId rec = new RecordId("myRec", "foo");
+		assertNotNull(rec.toString());
+		assertEquals("myRec", rec.getTable());
+		assertEquals("foo", rec.getId().getString());
+		rec.hashCode();
+	}
+
+	@Test
+	void recordIdWithLongKey() {
+		RecordId rec = new RecordId("myRec", 42L);
+		assertNotNull(rec.toString());
+		assertEquals("myRec", rec.getTable());
+		assertEquals(42L, rec.getId().getLong());
+		rec.hashCode();
+	}
+
+	@Test
+	void recordIdWithUuidKey() {
+		UUID uuid = UUID.randomUUID();
+		RecordId rec = new RecordId("myRec", uuid);
+		assertNotNull(rec.toString());
+		assertEquals("myRec", rec.getTable());
+		assertEquals(uuid, rec.getId().getUuid());
+		rec.hashCode();
+	}
+
+	@Test
+	void idFromLong() {
+		Id id = Id.from(7L);
+		assertTrue(id.isLong());
+		assertEquals(7L, id.getLong());
+		assertNotNull(id.toString());
+		id.hashCode();
+	}
+
+	@Test
+	void idFromString() {
+		Id id = Id.from("abc");
+		assertTrue(id.isString());
+		assertEquals("abc", id.getString());
+		assertNotNull(id.toString());
+		id.hashCode();
+	}
+
+	@Test
+	void idFromUuid() {
+		UUID uuid = UUID.randomUUID();
+		Id id = Id.from(uuid);
+		assertTrue(id.isUuid());
+		assertEquals(uuid, id.getUuid());
+		assertNotNull(id.toString());
+		id.hashCode();
+	}
+
+	@Test
+	void idFromCompositeArray() {
+		Id id = Id.from("a", 1L, true);
+		assertTrue(id.isArray());
+		assertNotNull(id.toString());
+		id.hashCode();
+	}
+
+	@Test
+	void arrayOfHeterogeneousElements() {
+		Array array = Array.of("a", 1L, true);
+		assertEquals(3, array.len());
+		assertNotNull(array.toString());
+		array.hashCode();
+	}
+}


### PR DESCRIPTION
## Summary

- Move `Loader.loadNative()` into the `Native` base class static initializer so every JNI-backed POJO (`RecordId`, `Id`, `Array`, …) auto-loads the native library on first reference. Java's JLS §12.4.1 superclass-init guarantee makes this work for every current and future subclass.
- Remove the now-redundant `static { Loader.loadNative(); }` blocks from `Surreal` and `LiveStream`.
- Decouple `Loader` from `Surreal.class` by switching its resource lookup to `Native.class` (it no longer depends on the class it bootstraps).
- Add `PojoStandaloneTests` covering `new RecordId(...)`, `Id.from(...)`, and `Array.of(...)` without referencing `Surreal`/`LiveStream`.

## Why

Previously, the following code threw `UnsatisfiedLinkError` unless a `Surreal` instance had been created elsewhere in the JVM:

```java
import com.surrealdb.RecordId;

void main() {
    var recId = new RecordId("myRec", "foo"); // fails when no Surreal instance is running
    System.out.println("Record ID: " + recId);
}
```

Only `Surreal` and `LiveStream` ran `Loader.loadNative()` from a static initializer, so any POJO touched first failed. Users constructing record IDs for validation, tests, or builder code without a live `Surreal` connection were broken.

## Why this is safe

- `System.loadLibrary` is idempotent — duplicate calls in a process are no-ops.
- JLS §12.4.1 guarantees a superclass is initialized before its subclass, so `Native`'s initializer always runs before any subclass constructor or static native call.
- `Loader.loadNative()` itself is unchanged — only the *trigger point* moves earlier.
- `LiveStream` does not extend `Native`, but its constructor is package-private and the only public path to obtain one is via `Surreal.selectLive(...)`, which guarantees `Surreal` (and thus `Native`) is already loaded.

## Test plan

- [x] New `PojoStandaloneTests` (8 tests) all pass: covers `RecordId` (String, long, UUID keys), `Id.from(long|String|UUID|Object...)`, and `Array.of(...)`. Each test also calls `.toString()` and `.hashCode()` so the inherited `Native` methods are exercised.
- [x] The test class deliberately avoids importing `Surreal` / `LiveStream` and carries a header comment explaining the invariant (so a future contributor doesn't silently mask the regression by reaching for `Surreal`).
- [x] `./gradlew build` — full Java + record-test source sets pass. Only failing test is `ConnectionTests.connectWebsocket()`, which is preexisting and environmental (requires a SurrealDB server at `ws://localhost:8000`).
- [x] Spotless format check passes.