### PR TITLE
Document snapshot installs and auto-publish them from main

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -370,7 +370,11 @@ jobs:
     needs:
       - aggregated-jar
       - integration-tests
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.run_optional_task == 'true'
+    # Manual dispatch always publishes (snapshot or release, based on version in build.gradle).
+    # Push to main auto-publishes only when the version is a SNAPSHOT; releases must be triggered manually.
+    if: |
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_optional_task == 'true') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -393,14 +397,31 @@ jobs:
           name: surrealdb
           path: native
 
-      - name: Publish Jar (Maven Central)
+      - name: Determine publish mode
+        id: mode
         run: |
           VERSION=$(grep '^version ' build.gradle | sed "s/version '\(.*\)'/\1/")
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           if [[ "$VERSION" == *-SNAPSHOT ]]; then
-            echo "Publishing SNAPSHOT to snapshots repository..."
+            echo "IS_SNAPSHOT=true" >> $GITHUB_OUTPUT
+          else
+            echo "IS_SNAPSHOT=false" >> $GITHUB_OUTPUT
+          fi
+          if [[ "${{ github.event_name }}" == "push" && "$VERSION" != *-SNAPSHOT ]]; then
+            echo "Push to main but version '$VERSION' is not a SNAPSHOT — releases must be triggered manually via workflow_dispatch."
+            echo "SHOULD_PUBLISH=false" >> $GITHUB_OUTPUT
+          else
+            echo "SHOULD_PUBLISH=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish Jar (Maven Central)
+        if: steps.mode.outputs.SHOULD_PUBLISH == 'true'
+        run: |
+          if [[ "${{ steps.mode.outputs.IS_SNAPSHOT }}" == "true" ]]; then
+            echo "Publishing SNAPSHOT ${{ steps.mode.outputs.VERSION }} to snapshots repository..."
             ./gradlew publishAggregationToCentralSnapshots
           else
-            echo "Publishing release to Central Portal..."
+            echo "Publishing release ${{ steps.mode.outputs.VERSION }} to Central Portal..."
             ./gradlew publishAggregationToCentralPortal
           fi
         env:
@@ -410,6 +431,7 @@ jobs:
           SIGNING_KEY_PASS: ${{ secrets.SIGNING_KEY_PASS }}
 
       - name: Publish Jar (GitHub Packages)
+        if: steps.mode.outputs.SHOULD_PUBLISH == 'true'
         run: ./gradlew publishMavenJavaPublicationToGitHubPackagesRepository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ View the SDK documentation [here](https://surrealdb.com/docs/integration/librari
 
 ## How to install
 
+### Stable release
+
+Released to [Maven Central](https://central.sonatype.com/artifact/com.surrealdb/surrealdb).
+
 Gradle:
 
 ```groovy
@@ -77,11 +81,53 @@ dependencies {
 Maven:
 
 ```xml
-
 <dependency>
     <groupId>com.surrealdb</groupId>
     <artifactId>surrealdb</artifactId>
     <version>2.0.2</version>
+</dependency>
+```
+
+### Snapshot release
+
+Published to the [Maven Central snapshots repository](https://central.sonatype.com/repository/maven-snapshots/) on every push to `main`. Use it to try out unreleased changes.
+
+Gradle:
+
+```groovy
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        mavenContent { snapshotsOnly() }
+    }
+}
+
+ext {
+    surrealdbVersion = "2.0.3-SNAPSHOT"
+}
+
+dependencies {
+    implementation "com.surrealdb:surrealdb:${surrealdbVersion}"
+}
+```
+
+Maven:
+
+```xml
+<repositories>
+    <repository>
+        <id>central-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        <releases><enabled>false</enabled></releases>
+        <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+</repositories>
+
+<dependency>
+    <groupId>com.surrealdb</groupId>
+    <artifactId>surrealdb</artifactId>
+    <version>2.0.3-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary

- README now shows two install sections — **Stable release** (latest Maven Central release) and **Snapshot release** (current `-SNAPSHOT` from the Central snapshots repo) — with Gradle + Maven snippets for each.
- `cross.yml` publishes automatically when a commit lands on `main` **and** the version in `build.gradle` ends with `-SNAPSHOT`. Releases (non-SNAPSHOT versions) still require manual `workflow_dispatch` with `run_optional_task=true`.

## Why

We want snapshot artifacts available on every merge to `main` so users can try unreleased changes without waiting for a tagged release, and the README should make both the stable and snapshot coordinates discoverable.

## How the new publish gate works

A new `Determine publish mode` step in the `publish` job reads the Gradle version and computes `SHOULD_PUBLISH`:

| Event | Version | Result |
|---|---|---|
| `push` to `main` | `*-SNAPSHOT` | Auto-publish snapshot |
| `push` to `main` | release | Skip (safety — releases must be manual) |
| `workflow_dispatch` (run_optional_task=true) | `*-SNAPSHOT` | Publish snapshot |
| `workflow_dispatch` (run_optional_task=true) | release | Publish release |

Both publish steps (Maven Central + GitHub Packages) are gated on `SHOULD_PUBLISH == 'true'`.

## Test plan

- [ ] CI green on this PR (no publish job runs on PR builds — only on `push` to `main` or manual dispatch)
- [ ] After merge: confirm the `publish` job runs on the push-to-main event and that `publishAggregationToCentralSnapshots` succeeds for the `2.0.3-SNAPSHOT` artifact
- [ ] Verify the snapshot artifact appears at https://central.sonatype.com/repository/maven-snapshots/com/surrealdb/surrealdb/
- [ ] Manual release flow still works: bump version off `-SNAPSHOT`, run workflow_dispatch with `run_optional_task=true`, confirm Central Portal publish