### PR TITLE
Add LiveStream regression tests over WebSocket and query() variants

### DIFF
--- a/src/test/java/com/surrealdb/LiveQueryQueryAsymmetryTests.java
+++ b/src/test/java/com/surrealdb/LiveQueryQueryAsymmetryTests.java
@@ -1,0 +1,145 @@
+package com.surrealdb;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Coverage gap pinned down by the investigation of issue
+ * <a href="https://github.com/surrealdb/surrealdb.java/issues/151">#151</a>:
+ * {@link Surreal.LiveStream} notifications must fire for every mutation
+ * entrypoint, not only the typed {@link Surreal#create(RecordId, Object)}
+ * overload that the existing {@link LiveQueryTests} suite exercises.
+ *
+ * <p>
+ * In practice every {@code create()} / {@code update()} overload and every
+ * {@link Surreal#query(String)} / {@link Surreal#query(String, java.util.Map)}
+ * variant routes through {@code surrealdb_query} → {@code surreal.query(...)}
+ * in {@code src/main/rust/surreal.rs}, so an SDK-layer asymmetry isn't
+ * architecturally possible. These tests lock that in for the in-memory engine.
+ * The WebSocket counterpart lives in {@link LiveQueryWebSocketTests}.
+ */
+public class LiveQueryQueryAsymmetryTests {
+
+	private static Optional<LiveNotification> awaitOne(LiveStream stream, Runnable trigger) throws Exception {
+		AtomicReference<Optional<LiveNotification>> got = new AtomicReference<>(Optional.empty());
+		AtomicReference<Throwable> err = new AtomicReference<>();
+		CountDownLatch started = new CountDownLatch(1);
+
+		Thread consumer = new Thread(() -> {
+			try {
+				started.countDown();
+				got.set(stream.next());
+			} catch (Throwable t) {
+				err.set(t);
+			}
+		});
+		consumer.setDaemon(true);
+		consumer.start();
+
+		started.await(2, TimeUnit.SECONDS);
+		Thread.sleep(200);
+
+		trigger.run();
+
+		consumer.join(5000);
+		if (err.get() != null) {
+			throw new RuntimeException(err.get());
+		}
+		assertFalse(consumer.isAlive(), "Consumer thread still blocked");
+		return got.get();
+	}
+
+	@Test
+	void query_createWithRawSql_firesNotification() throws Exception {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test").useDb("test");
+			surreal.query("DEFINE TABLE person SCHEMALESS");
+
+			try (LiveStream stream = surreal.selectLive("person")) {
+				Optional<LiveNotification> n = awaitOne(stream,
+						() -> surreal.query("CREATE person:1 CONTENT { name: 'tobie' }"));
+				assertNotNull(n.orElse(null), "No notification after query(\"CREATE ...\")");
+				assertEquals("CREATE", n.get().getAction().toUpperCase());
+			}
+		}
+	}
+
+	@Test
+	void query_createWithBindings_firesNotification() throws Exception {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test").useDb("test");
+			surreal.query("DEFINE TABLE person SCHEMALESS");
+
+			try (LiveStream stream = surreal.selectLive("person")) {
+				Map<String, java.lang.Object> params = new HashMap<>();
+				params.put("name", "tobie");
+				Optional<LiveNotification> n = awaitOne(stream,
+						() -> surreal.query("CREATE person:1 SET name = $name", params));
+				assertNotNull(n.orElse(null), "No notification after query(...) with bindings");
+				assertEquals("CREATE", n.get().getAction().toUpperCase());
+			}
+		}
+	}
+
+	@Test
+	void query_createWithTypeRecord_firesNotification() throws Exception {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test").useDb("test");
+			surreal.query("DEFINE TABLE person SCHEMALESS");
+
+			try (LiveStream stream = surreal.selectLive("person")) {
+				Map<String, java.lang.Object> params = new HashMap<>();
+				params.put("id", "person:1");
+				params.put("name", "tobie");
+				Optional<LiveNotification> n = awaitOne(stream, () -> surreal
+						.query("CREATE type::record($id) CONTENT { name: $name, status: 'pending' }", params));
+				assertNotNull(n.orElse(null), "No notification after query(\"CREATE type::record($id) CONTENT ...\")");
+				assertEquals("CREATE", n.get().getAction().toUpperCase());
+			}
+		}
+	}
+
+	@Test
+	void query_updateWithWhereReturnBefore_firesNotification() throws Exception {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test").useDb("test");
+			surreal.query("DEFINE TABLE person SCHEMALESS");
+			surreal.query("CREATE person:1 CONTENT { name: 'tobie', status: 'pending' }");
+
+			try (LiveStream stream = surreal.selectLive("person")) {
+				Map<String, java.lang.Object> params = new HashMap<>();
+				params.put("id", "person:1");
+				Optional<LiveNotification> n = awaitOne(stream, () -> surreal.query(
+						"UPDATE type::record($id) SET status = 'completed' WHERE status = 'pending' RETURN BEFORE",
+						params));
+				assertNotNull(n.orElse(null), "No notification after conditional UPDATE ... RETURN BEFORE");
+				assertEquals("UPDATE", n.get().getAction().toUpperCase());
+			}
+		}
+	}
+
+	@Test
+	void query_updateSimple_firesNotification() throws Exception {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test").useDb("test");
+			surreal.query("DEFINE TABLE person SCHEMALESS");
+			surreal.query("CREATE person:1 CONTENT { name: 'tobie' }");
+
+			try (LiveStream stream = surreal.selectLive("person")) {
+				Optional<LiveNotification> n = awaitOne(stream,
+						() -> surreal.query("UPDATE person:1 SET name = 'jaime'"));
+				assertNotNull(n.orElse(null), "No notification after plain UPDATE via query()");
+				assertEquals("UPDATE", n.get().getAction().toUpperCase());
+			}
+		}
+	}
+}

--- a/src/test/java/com/surrealdb/LiveQueryWebSocketTests.java
+++ b/src/test/java/com/surrealdb/LiveQueryWebSocketTests.java
@@ -1,0 +1,231 @@
+package com.surrealdb;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import org.junit.jupiter.api.Test;
+
+import com.surrealdb.signin.RootCredential;
+
+/**
+ * Regression tests for issue
+ * <a href="https://github.com/surrealdb/surrealdb.java/issues/151">#151</a>:
+ * {@link Surreal#selectLive(String)} must deliver notifications over a
+ * WebSocket connection, not only the in-memory engine.
+ *
+ * <p>
+ * Notifications are exercised through every mutation entrypoint that ultimately
+ * routes through {@code surreal.query(...)} in the Rust layer:
+ * <ul>
+ * <li>typed {@link Surreal#create(RecordId, Object)},</li>
+ * <li>raw {@link Surreal#query(String)} with inline {@code CREATE},</li>
+ * <li>parameterised {@link Surreal#query(String, Map)} with {@code $name}
+ * bindings,</li>
+ * <li>{@code CREATE type::record($id) CONTENT { ... }},</li>
+ * <li>conditional {@code UPDATE ... WHERE ... RETURN BEFORE}.</li>
+ * </ul>
+ *
+ * <p>
+ * These tests require a SurrealDB server running at {@code ws://localhost:8000}
+ * with a root user named {@code root}/{@code root}. CI provides one via
+ * {@code surrealdb/setup-surreal} which starts SurrealDB with
+ * {@code -u root -p root --unauthenticated --allow-all}. Locally, run:
+ *
+ * <pre>{@code
+ * surreal start -u root -p root --unauthenticated --allow-all --bind 127.0.0.1:8000 memory
+ * }</pre>
+ *
+ * If the server is unreachable, every test is skipped via {@code assumeTrue}.
+ */
+public class LiveQueryWebSocketTests {
+
+	private static final String WS_URL = "ws://localhost:8000";
+	private static final int CONNECT_TIMEOUT_SECONDS = 5;
+
+	/**
+	 * Opens a WS connection on a worker thread with a hard timeout so a missing
+	 * server doesn't hang the suite. Returns {@code null} when unreachable, which
+	 * the caller turns into a JUnit skip via
+	 * {@link org.junit.jupiter.api.Assumptions#assumeTrue}.
+	 */
+	private static Surreal tryConnectWs() {
+		Surreal surreal = new Surreal();
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Future<Void> f = executor.submit(new Callable<Void>() {
+				@Override
+				public Void call() {
+					surreal.connect(WS_URL);
+					surreal.signin(new RootCredential("root", "root"));
+					surreal.useNs("livetest").useDb("livetest");
+					return null;
+				}
+			});
+			f.get(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			return surreal;
+		} catch (TimeoutException | InterruptedException | java.util.concurrent.ExecutionException e) {
+			surreal.close();
+			return null;
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	/**
+	 * Blocks on {@code stream.next()} on a worker thread, runs {@code trigger}
+	 * after a short delay so the subscription is definitely established, and
+	 * returns whatever notification arrived (or empty if {@code next()} returned
+	 * before any mutation).
+	 */
+	private static Optional<LiveNotification> awaitOne(LiveStream stream, Runnable trigger) throws Exception {
+		AtomicReference<Optional<LiveNotification>> got = new AtomicReference<>(Optional.empty());
+		AtomicReference<Throwable> err = new AtomicReference<>();
+		CountDownLatch started = new CountDownLatch(1);
+
+		Thread consumer = new Thread(() -> {
+			try {
+				started.countDown();
+				got.set(stream.next());
+			} catch (Throwable t) {
+				err.set(t);
+			}
+		});
+		consumer.setDaemon(true);
+		consumer.start();
+
+		started.await(2, TimeUnit.SECONDS);
+		Thread.sleep(300);
+
+		trigger.run();
+
+		consumer.join(5000);
+		if (err.get() != null) {
+			throw new RuntimeException(err.get());
+		}
+		assertFalse(consumer.isAlive(), "Consumer thread still blocked — next() never returned");
+		return got.get();
+	}
+
+	@Test
+	void selectLive_overWebSocket_typedCreate_firesNotification() throws Exception {
+		Surreal surreal = tryConnectWs();
+		assumeTrue(surreal != null, "SurrealDB not reachable at " + WS_URL);
+		try (Surreal s = surreal) {
+			s.query("REMOVE TABLE IF EXISTS ws_person; DEFINE TABLE ws_person SCHEMALESS");
+			try (LiveStream stream = s.selectLive("ws_person")) {
+				Optional<LiveNotification> n = awaitOne(stream,
+						() -> s.create(new RecordId("ws_person", 1), Helpers.tobie));
+				assertNotNull(n.orElse(null), "No notification after typed create() over WS");
+				assertEquals("CREATE", n.get().getAction().toUpperCase());
+			}
+		}
+	}
+
+	@Test
+	void selectLive_overWebSocket_queryCreateInlineSql_firesNotification() throws Exception {
+		Surreal surreal = tryConnectWs();
+		assumeTrue(surreal != null, "SurrealDB not reachable at " + WS_URL);
+		try (Surreal s = surreal) {
+			s.query("REMOVE TABLE IF EXISTS ws_person; DEFINE TABLE ws_person SCHEMALESS");
+			try (LiveStream stream = s.selectLive("ws_person")) {
+				Optional<LiveNotification> n = awaitOne(stream,
+						() -> s.query("CREATE ws_person:1 CONTENT { name: 'tobie' }"));
+				assertNotNull(n.orElse(null), "No notification after query(\"CREATE ...\") over WS");
+				assertEquals("CREATE", n.get().getAction().toUpperCase());
+			}
+		}
+	}
+
+	@Test
+	void selectLive_overWebSocket_queryCreateWithBindings_firesNotification() throws Exception {
+		Surreal surreal = tryConnectWs();
+		assumeTrue(surreal != null, "SurrealDB not reachable at " + WS_URL);
+		try (Surreal s = surreal) {
+			s.query("REMOVE TABLE IF EXISTS ws_person; DEFINE TABLE ws_person SCHEMALESS");
+			try (LiveStream stream = s.selectLive("ws_person")) {
+				Map<String, java.lang.Object> params = new HashMap<>();
+				params.put("name", "tobie");
+				Optional<LiveNotification> n = awaitOne(stream,
+						() -> s.query("CREATE ws_person:1 SET name = $name", params));
+				assertNotNull(n.orElse(null), "No notification after parameterised query() CREATE over WS");
+				assertEquals("CREATE", n.get().getAction().toUpperCase());
+			}
+		}
+	}
+
+	@Test
+	void selectLive_overWebSocket_queryCreateWithTypeRecord_firesNotification() throws Exception {
+		Surreal surreal = tryConnectWs();
+		assumeTrue(surreal != null, "SurrealDB not reachable at " + WS_URL);
+		try (Surreal s = surreal) {
+			s.query("REMOVE TABLE IF EXISTS ws_person; DEFINE TABLE ws_person SCHEMALESS");
+			try (LiveStream stream = s.selectLive("ws_person")) {
+				Map<String, java.lang.Object> params = new HashMap<>();
+				params.put("id", "ws_person:1");
+				params.put("name", "tobie");
+				Optional<LiveNotification> n = awaitOne(stream,
+						() -> s.query("CREATE type::record($id) CONTENT { name: $name, status: 'pending' }", params));
+				assertNotNull(n.orElse(null),
+						"No notification after query(\"CREATE type::record($id) CONTENT ...\") over WS");
+				assertEquals("CREATE", n.get().getAction().toUpperCase());
+			}
+		}
+	}
+
+	@Test
+	void selectLive_overWebSocket_queryUpdateWhereReturnBefore_firesNotification() throws Exception {
+		Surreal surreal = tryConnectWs();
+		assumeTrue(surreal != null, "SurrealDB not reachable at " + WS_URL);
+		try (Surreal s = surreal) {
+			s.query("REMOVE TABLE IF EXISTS ws_person; DEFINE TABLE ws_person SCHEMALESS");
+			s.query("CREATE ws_person:1 CONTENT { name: 'tobie', status: 'pending' }");
+			try (LiveStream stream = s.selectLive("ws_person")) {
+				Map<String, java.lang.Object> params = new HashMap<>();
+				params.put("id", "ws_person:1");
+				Optional<LiveNotification> n = awaitOne(stream, () -> s.query(
+						"UPDATE type::record($id) SET status = 'completed' WHERE status = 'pending' RETURN BEFORE",
+						params));
+				assertNotNull(n.orElse(null), "No notification after conditional UPDATE ... RETURN BEFORE over WS");
+				assertEquals("UPDATE", n.get().getAction().toUpperCase());
+			}
+		}
+	}
+
+	@Test
+	void selectLive_overWebSocket_close_unblocksNext() throws Exception {
+		Surreal surreal = tryConnectWs();
+		assumeTrue(surreal != null, "SurrealDB not reachable at " + WS_URL);
+		try (Surreal s = surreal) {
+			s.query("REMOVE TABLE IF EXISTS ws_person; DEFINE TABLE ws_person SCHEMALESS");
+			LiveStream stream = s.selectLive("ws_person");
+			AtomicReference<Optional<LiveNotification>> got = new AtomicReference<>();
+			CountDownLatch started = new CountDownLatch(1);
+			Thread consumer = new Thread(() -> {
+				started.countDown();
+				got.set(stream.next());
+			});
+			consumer.setDaemon(true);
+			consumer.start();
+			started.await(2, TimeUnit.SECONDS);
+			Thread.sleep(300);
+			stream.close();
+			consumer.join(5000);
+			assertFalse(consumer.isAlive(), "next() did not return after close() over WS");
+			assertNotNull(got.get(), "next() returned null Optional");
+			assertFalse(got.get().isPresent(), "next() should return empty after close()");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #151 by adding regression coverage; investigation summary in [internal session, 2026-05-22].

- **`LiveQueryWebSocketTests`** — proves `Surreal.selectLive(...)` delivers notifications over `ws://localhost:8000`, the scenario reported in [#151](https://github.com/surrealdb/surrealdb.java/issues/151). Runs against the same fixture CI already provisions (`surrealdb/setup-surreal` → `-u root -p root --unauthenticated --allow-all`). Tests are skipped via `assumeTrue` when the server is unreachable, so the regular `./gradlew test` still passes locally without a server.
- **`LiveQueryQueryAsymmetryTests`** — covers a gap in the existing `LiveQueryTests`: every mutation entrypoint routes through `surrealdb_query` → `surreal.query(...)` in the Rust layer ([surreal.rs:614](https://github.com/surrealdb/surrealdb.java/blob/main/src/main/rust/surreal.rs#L614)), so notifications must fire equally for typed `create(RecordId, T)` *and* raw `query("CREATE …")`. The new tests exercise raw CREATE, parameterised CREATE, `CREATE type::record($id)`, plain UPDATE, and conditional `UPDATE … WHERE … RETURN BEFORE`.

Context: [#151](https://github.com/surrealdb/surrealdb.java/issues/151) was filed against v2.0.1, before [PR #139](https://github.com/surrealdb/surrealdb.java/pull/139) (commit 99d422d, 2026-04-26) reworked the LIVE-query JNI path. v2.0.2 ships the fix. These tests lock in the post-fix behaviour over WS so a future regression would surface in CI.

## Test plan

- [x] `./gradlew test --tests 'com.surrealdb.LiveQueryQueryAsymmetryTests'` — 5/5 pass
- [x] `./gradlew test --tests 'com.surrealdb.LiveQueryWebSocketTests'` — 6/6 pass against a local `surreal start -u root -p root --unauthenticated --allow-all --bind 127.0.0.1:8000 memory`
- [x] Full `./gradlew test` — 289 tests, 0 failures, 2 skipped (unchanged baseline)
- [x] `./gradlew spotlessJavaCheck` — clean