### PR TITLE
fix: avoid spawning a new server session per health/version/export/import

### DIFF
--- a/src/integrationTest/java/com/surrealdb/integration/IntegrationTest.java
+++ b/src/integrationTest/java/com/surrealdb/integration/IntegrationTest.java
@@ -6,14 +6,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import com.surrealdb.Surreal;
 import com.surrealdb.SurrealException;
-import com.surrealdb.signin.RootCredential;
 
 public class IntegrationTest {
 
@@ -47,33 +45,6 @@ public class IntegrationTest {
 	void surreal_db_memory() throws SurrealException {
 		try (Surreal surreal = new Surreal()) {
 			surreal.connect("memory");
-		}
-	}
-
-	/**
-	 * Regression test for
-	 * <a href= "https://github.com/surrealdb/surrealdb.java/issues/160">#160</a>:
-	 * looping useDb + health on a reused WebSocket connection used to balloon the
-	 * SDK's per-session replay log and (on server 3.0.5) crash the server worker. A
-	 * fixed driver finishes the loop quickly with stable per-iteration latency.
-	 */
-	@Test
-	@EnabledOnOs({OS.LINUX, OS.MAC})
-	void useDbHealthLoop_doesNotDegrade() {
-		final int iterations = 200;
-		final long budgetMs = 10_000;
-		try (Surreal surreal = new Surreal()) {
-			surreal.connect("ws://localhost:8000");
-			surreal.signin(new RootCredential("root", "root"));
-			surreal.useNs("issue_160_ns");
-			long start = System.currentTimeMillis();
-			for (int i = 0; i < iterations; i++) {
-				surreal.useDb("issue_160_db");
-				surreal.health();
-			}
-			long elapsed = System.currentTimeMillis() - start;
-			assertTrue(elapsed < budgetMs,
-					"useDb+health loop took " + elapsed + "ms (>" + budgetMs + "ms); replay log may be growing");
 		}
 	}
 }

--- a/src/integrationTest/java/com/surrealdb/integration/IntegrationTest.java
+++ b/src/integrationTest/java/com/surrealdb/integration/IntegrationTest.java
@@ -6,12 +6,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import com.surrealdb.Surreal;
 import com.surrealdb.SurrealException;
+import com.surrealdb.signin.RootCredential;
 
 public class IntegrationTest {
 
@@ -45,6 +47,33 @@ public class IntegrationTest {
 	void surreal_db_memory() throws SurrealException {
 		try (Surreal surreal = new Surreal()) {
 			surreal.connect("memory");
+		}
+	}
+
+	/**
+	 * Regression test for <a href=
+	 * "https://github.com/surrealdb/surrealdb.java/issues/160">#160</a>: looping
+	 * useDb + health on a reused WebSocket connection used to balloon the SDK's
+	 * per-session replay log and (on server 3.0.5) crash the server worker. A
+	 * fixed driver finishes the loop quickly with stable per-iteration latency.
+	 */
+	@Test
+	@EnabledOnOs({OS.LINUX, OS.MAC})
+	void useDbHealthLoop_doesNotDegrade() {
+		final int iterations = 200;
+		final long budgetMs = 10_000;
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("ws://localhost:8000");
+			surreal.signin(new RootCredential("root", "root"));
+			surreal.useNs("issue_160_ns");
+			long start = System.currentTimeMillis();
+			for (int i = 0; i < iterations; i++) {
+				surreal.useDb("issue_160_db");
+				surreal.health();
+			}
+			long elapsed = System.currentTimeMillis() - start;
+			assertTrue(elapsed < budgetMs,
+					"useDb+health loop took " + elapsed + "ms (>" + budgetMs + "ms); replay log may be growing");
 		}
 	}
 }

--- a/src/integrationTest/java/com/surrealdb/integration/IntegrationTest.java
+++ b/src/integrationTest/java/com/surrealdb/integration/IntegrationTest.java
@@ -51,10 +51,10 @@ public class IntegrationTest {
 	}
 
 	/**
-	 * Regression test for <a href=
-	 * "https://github.com/surrealdb/surrealdb.java/issues/160">#160</a>: looping
-	 * useDb + health on a reused WebSocket connection used to balloon the SDK's
-	 * per-session replay log and (on server 3.0.5) crash the server worker. A
+	 * Regression test for
+	 * <a href= "https://github.com/surrealdb/surrealdb.java/issues/160">#160</a>:
+	 * looping useDb + health on a reused WebSocket connection used to balloon the
+	 * SDK's per-session replay log and (on server 3.0.5) crash the server worker. A
 	 * fixed driver finishes the loop quickly with stable per-iteration latency.
 	 */
 	@Test

--- a/src/main/rust/surreal.rs
+++ b/src/main/rust/surreal.rs
@@ -89,7 +89,7 @@ pub extern "system" fn Java_com_surrealdb_Surreal_version<'local>(
     ptr: jlong,
 ) -> jstring {
     let surreal = get_surreal_ref!(&mut env, ptr, null_mut);
-    let version = match TOKIO_RUNTIME.block_on(async { surreal.clone().version().await }) {
+    let version = match TOKIO_RUNTIME.block_on(async { surreal.version().await }) {
         Ok(v) => v.to_string(),
         // Embedded / local: no server to ask; report library version (injected at build time)
         Err(_) => env!("SURREALDB_VERSION").into(),
@@ -104,7 +104,7 @@ pub extern "system" fn Java_com_surrealdb_Surreal_health<'local>(
     ptr: jlong,
 ) -> jboolean {
     let surreal = get_surreal_ref!(&mut env, ptr, || false as jboolean);
-    match TOKIO_RUNTIME.block_on(async { surreal.clone().health().await }) {
+    match TOKIO_RUNTIME.block_on(async { surreal.health().await }) {
         Ok(()) => true as jboolean,
         Err(e) => SurrealError::from(e).exception(&mut env, || false as jboolean),
     }
@@ -589,7 +589,7 @@ pub extern "system" fn Java_com_surrealdb_Surreal_exportSql<'local>(
     let surreal = get_surreal_ref!(&mut env, ptr, || false as jboolean);
     let path = get_rust_string!(&mut env, &path, || false as jboolean);
     let path = Path::new(&path).to_path_buf();
-    match TOKIO_RUNTIME.block_on(async { surreal.clone().export(path).await }) {
+    match TOKIO_RUNTIME.block_on(async { surreal.export(path).await }) {
         Ok(()) => true as jboolean,
         Err(e) => SurrealError::from(e).exception(&mut env, || false as jboolean),
     }
@@ -605,7 +605,7 @@ pub extern "system" fn Java_com_surrealdb_Surreal_importSql<'local>(
     let surreal = get_surreal_ref!(&mut env, ptr, || false as jboolean);
     let path = get_rust_string!(&mut env, &path, || false as jboolean);
     let path = Path::new(&path).to_path_buf();
-    match TOKIO_RUNTIME.block_on(async { surreal.clone().import(path).await }) {
+    match TOKIO_RUNTIME.block_on(async { surreal.import(path).await }) {
         Ok(()) => true as jboolean,
         Err(e) => SurrealError::from(e).exception(&mut env, || false as jboolean),
     }

--- a/src/test/java/com/surrealdb/Issue160RegressionTests.java
+++ b/src/test/java/com/surrealdb/Issue160RegressionTests.java
@@ -1,0 +1,52 @@
+package com.surrealdb;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import com.surrealdb.signin.RootCredential;
+
+/**
+ * Regression coverage for
+ * <a href="https://github.com/surrealdb/surrealdb.java/issues/160">#160</a>.
+ * The reported bug: calling {@code useDb} + {@code health} in a loop on a
+ * reused WebSocket connection ballooned the SDK's per-session replay log and
+ * (on server 3.0.5) crashed the server worker. A fixed driver finishes the loop
+ * quickly with stable per-iteration latency.
+ * <p>
+ * Skipped when no SurrealDB instance is reachable at
+ * {@code ws://localhost:8000} so local {@code ./gradlew test} runs without a
+ * server stay green; CI starts one before the test step.
+ */
+public class Issue160RegressionTests {
+
+	private static final String WS_URL = "ws://localhost:8000";
+
+	@Test
+	@EnabledOnOs({OS.LINUX, OS.MAC})
+	void useDbHealthLoop_doesNotDegrade() {
+		final int iterations = 200;
+		final long budgetMs = 10_000;
+		try (Surreal surreal = new Surreal()) {
+			try {
+				surreal.connect(WS_URL);
+				surreal.signin(new RootCredential("root", "root"));
+			} catch (Exception e) {
+				assumeTrue(false, "Skipping: no SurrealDB reachable at " + WS_URL + " (" + e.getMessage() + ")");
+				return;
+			}
+			surreal.useNs("issue_160_ns");
+			long start = System.currentTimeMillis();
+			for (int i = 0; i < iterations; i++) {
+				surreal.useDb("issue_160_db");
+				surreal.health();
+			}
+			long elapsed = System.currentTimeMillis() - start;
+			assertTrue(elapsed < budgetMs,
+					"useDb+health loop took " + elapsed + "ms (>" + budgetMs + "ms); replay log may be growing");
+		}
+	}
+}


### PR DESCRIPTION
Closes #160.

## Why

In surrealdb 3.x, `Surreal::clone()` is no longer a cheap Arc-clone — it allocates a fresh `session_id` and asks the engine to clone the current session state into it, then replays every recorded `Use`/`Signin`/`Set`/etc. command on the new session. For methods that take `&self` (`health`, `version`, `export`, `import`), wrapping the call in `surreal.clone().*()` was creating and tearing down a server session on every invocation.

In the issue #160 reproduction (`useDb` + `health` in a loop on a reused WebSocket connection):

1. Each `useDb` appends a `Use{ns:None, db:Some("my_db")}` to the SDK's per-session replay log (`Command::Use` is `replayable()`).
2. Each `health()` triggers `Surreal::clone()` → new server session attached → entire replay log replayed (fire-and-forget) on the new session → session detached.
3. After N iterations, every `health()` call blasts N+1 `use` messages over the wire.

Against server 3.0.5, the racy replay of `Use{ns:None, db:my_db}` on a freshly attached session hit `core/src/rpc/protocol.rs:350` (`namespace should be set`), aborting the worker. Against 3.1.0 (server-side panic patched), the replay just keeps growing — hence "queries get slower and slower" in the bug report.

The `get_surreal_ref!` macro [already documents this gotcha](src/main/rust/macros.rs#L31-L34); the four fixed callsites just predate the comment.

`beginTransaction` (takes `self` by value) and `selectLive` (spawned thread needs owned handle) legitimately need their clones and are unchanged.

## Follow-up in the Rust SDK

Even with this fix, a `useNs`/`useDb` loop on the same session would still grow the replay log linearly, which becomes visible if the user later calls anything that legitimately clones the session. The companion PR in \`surrealdb-private\` coalesces idempotent \`Use\` entries in the replay log.

## Test plan

- [x] \`cargo check\` clean, no Rust-side regressions
- [x] New regression test \`Issue160RegressionTests.useDbHealthLoop_doesNotDegrade\` in \`src/test/java/com/surrealdb/\` loops \`useDb\` + \`health\` 200× against \`ws://localhost:8000\` and asserts the loop stays under 10s; would have failed pre-fix
- [x] Guarded by \`Assumptions.assumeTrue(false, …)\` on connect failure so local \`./gradlew test\` without a server reports SKIPPED (verified locally)
- [x] CI: \`test.yml\` starts SurrealDB before \`./gradlew -i test jacocoTestReport\`, so the regression runs on every PR (previously the test lived in \`src/integrationTest\` and only ran via the slower \`cross.yml\` pipeline)

## Repro
The reporter's reproduction is at https://github.com/PepperSniffer/surrealdb-bug-report.