### PR TITLE
Prepare release 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
-## [Unreleased]
-- Support Java `record` classes in `create` and `select` (JDK 16+ at runtime). Records are hydrated via their canonical constructor; POJO behaviour on JDK 8+ is unchanged.
+## [2.0.3] - 2026-05-29
+- Support Java `record` classes in `create` and `select` (JDK 16+ at runtime). Records are hydrated via their canonical constructor; POJO behaviour on JDK 8+ is unchanged [#156](https://github.com/surrealdb/surrealdb.java/pull/156).
+- Add `Array.of()` and `Id.from(Object...)` factories for composite keys [#154](https://github.com/surrealdb/surrealdb.java/pull/154).
+- Fix nullable `Boolean` and `Optional<T>` (de)serialization [#155](https://github.com/surrealdb/surrealdb.java/pull/155).
+- Auto-load the native library on first use of any Native-backed POJO [#157](https://github.com/surrealdb/surrealdb.java/pull/157).
+- Avoid spawning a new server session per health/version/export/import call [#161](https://github.com/surrealdb/surrealdb.java/pull/161).
+- Document snapshot installs and auto-publish snapshots from `main` [#158](https://github.com/surrealdb/surrealdb.java/pull/158).
+- Add LiveStream regression tests over WebSocket and `query()` variants [#159](https://github.com/surrealdb/surrealdb.java/pull/159).
 
 ## [2.0.2] - 2026-05-20
 - Add Java query binding overloads and transaction bindings [#148](https://github.com/surrealdb/surrealdb.java/pull/148).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Gradle:
 
 ```groovy
 ext {
-    surrealdbVersion = "2.0.2"
+    surrealdbVersion = "2.0.3"
 }
 
 dependencies {
@@ -84,7 +84,7 @@ Maven:
 <dependency>
     <groupId>com.surrealdb</groupId>
     <artifactId>surrealdb</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
 }
 
 group 'com.surrealdb'
-version '2.0.3-SNAPSHOT'
+version '2.0.3'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Release-prep PR for **2.0.3** (last release: v2.0.2).

## Changes
- Bump `build.gradle` version `2.0.3-SNAPSHOT` → `2.0.3`.
- Update the README **stable install** snippets (Gradle + Maven) to `2.0.3`.
- Promote the CHANGELOG `[Unreleased]` section to `## [2.0.3] - 2026-05-29` and fill in all shipped PRs.

## Included since v2.0.2
- Support Java `record` classes in `create`/`select` (#156)
- Add `Array.of()` and `Id.from(Object...)` factories for composite keys (#154)
- Fix nullable `Boolean` and `Optional<T>` (de)serialization (#155)
- Auto-load the native library on first use of any Native-backed POJO (#157)
- Avoid spawning a new server session per health/version/export/import call (#161)
- Document snapshot installs and auto-publish snapshots from `main` (#158)
- Add LiveStream regression tests over WebSocket and `query()` variants (#159)

## Release steps after merge
1. Manually trigger the **Cross-Compile** workflow with `Publish? = true` to publish 2.0.3 to Maven Central + GitHub Packages (push-to-main does **not** publish release versions).
2. Tag `v2.0.3` (annotated) and create the GitHub release.
3. Follow-up PR to bump to `2.0.4-SNAPSHOT`.

The README **snapshot** section is intentionally left at `2.0.3-SNAPSHOT`; it moves to `2.0.4-SNAPSHOT` in the post-release bump.