### PR TITLE
Bump version to 2.1.0-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [2.0.3] - 2026-05-29
 - Support Java `record` classes in `create` and `select` (JDK 16+ at runtime). Records are hydrated via their canonical constructor; POJO behaviour on JDK 8+ is unchanged [#156](https://github.com/surrealdb/surrealdb.java/pull/156).
 - Add `Array.of()` and `Id.from(Object...)` factories for composite keys [#154](https://github.com/surrealdb/surrealdb.java/pull/154).

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ repositories {
 }
 
 ext {
-    surrealdbVersion = "2.0.3-SNAPSHOT"
+    surrealdbVersion = "2.1.0-SNAPSHOT"
 }
 
 dependencies {
@@ -127,7 +127,7 @@ Maven:
 <dependency>
     <groupId>com.surrealdb</groupId>
     <artifactId>surrealdb</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
 }
 
 group 'com.surrealdb'
-version '2.0.3'
+version '2.1.0-SNAPSHOT'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Post-release version bump following the **2.0.3** release ([v2.0.3](https://github.com/surrealdb/surrealdb.java/releases/tag/v2.0.3)).

Targets the next **minor** version (`2.1.0-SNAPSHOT`) rather than a patch, in anticipation of new features in the 2.x line.

## Changes
- Bump `build.gradle` version `2.0.3` → `2.1.0-SNAPSHOT`, so pushes to `main` resume auto-publishing snapshots.
- Update the README **snapshot install** snippets (Gradle + Maven) to `2.1.0-SNAPSHOT`.
- Restore a `## [Unreleased]` heading in the CHANGELOG for the next set of changes.

The README **stable** section stays at `2.0.3` (the current released version).

Supersedes #163.