### PR TITLE
Prepare release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.1.0] - 2026-06-04
 - Upgrade the native layer to the `jni` crate 0.22.4; the Java/JNI ABI, public API, and JDK 8 minimum are unchanged [#166](https://github.com/surrealdb/surrealdb.java/pull/166).
 - Upgrade to SurrealDB SDK 3.1.3 and bump the Rust toolchain to 1.95 [#165](https://github.com/surrealdb/surrealdb.java/pull/165).
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Gradle:
 
 ```groovy
 ext {
-    surrealdbVersion = "2.0.3"
+    surrealdbVersion = "2.1.0"
 }
 
 dependencies {
@@ -84,7 +84,7 @@ Maven:
 <dependency>
     <groupId>com.surrealdb</groupId>
     <artifactId>surrealdb</artifactId>
-    <version>2.0.3</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
 }
 
 group 'com.surrealdb'
-version '2.1.0-SNAPSHOT'
+version '2.1.0'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Prepare release 2.1.0

Cuts the `2.1.0` minor from `main`. Version-and-docs only — no source changes.

### Changes in this release
- Upgrade to SurrealDB SDK 3.1.3 and bump the Rust toolchain to 1.95 ([#165](https://github.com/surrealdb/surrealdb.java/pull/165)).
- Upgrade the native layer to the `jni` crate 0.22.4; the Java/JNI ABI, public API, and JDK 8 minimum are unchanged ([#166](https://github.com/surrealdb/surrealdb.java/pull/166)).

No Java API changes — consumers upgrade with no code modifications.

### This PR
- `build.gradle`: `2.1.0-SNAPSHOT` → `2.1.0`
- `CHANGELOG.md`: `[Unreleased]` → `[2.1.0] - 2026-06-04`
- `README.md`: stable-install examples → `2.1.0`

### Release steps after merge
1. Tag `v2.1.0` on the merged commit.
2. Manually dispatch `cross.yml` with `run_optional_task=true` against the tag to publish to Maven Central + GitHub Packages.
3. Follow-up PR bumps `main` to `2.1.1-SNAPSHOT`.

> Merging this is safe: a push to `main` with a non-SNAPSHOT version does **not** auto-publish (the publish job sets `SHOULD_PUBLISH=false`). Publishing requires an explicit `workflow_dispatch`.
