### PR TITLE
Bump version to 2.1.1-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [2.1.0] - 2026-06-04
 - Upgrade the native layer to the `jni` crate 0.22.4; the Java/JNI ABI, public API, and JDK 8 minimum are unchanged [#166](https://github.com/surrealdb/surrealdb.java/pull/166).
 - Upgrade to SurrealDB SDK 3.1.3 and bump the Rust toolchain to 1.95 [#165](https://github.com/surrealdb/surrealdb.java/pull/165).

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ repositories {
 }
 
 ext {
-    surrealdbVersion = "2.1.0-SNAPSHOT"
+    surrealdbVersion = "2.1.1-SNAPSHOT"
 }
 
 dependencies {
@@ -127,7 +127,7 @@ Maven:
 <dependency>
     <groupId>com.surrealdb</groupId>
     <artifactId>surrealdb</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
 }
 
 group 'com.surrealdb'
-version '2.1.0'
+version '2.1.1-SNAPSHOT'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Bump to 2.1.1-SNAPSHOT

Reopens `main` for development after the `2.1.0` release ([tag v2.1.0](https://github.com/surrealdb/surrealdb.java/releases/tag/v2.1.0), published to Maven Central + GitHub Packages).

- `build.gradle`: `2.1.0` → `2.1.1-SNAPSHOT`
- `README.md`: snapshot-install examples → `2.1.1-SNAPSHOT`
- `CHANGELOG.md`: add a fresh `## [Unreleased]` section above `## [2.1.0]`

On merge, the normal snapshot auto-publish resumes (`2.1.1-SNAPSHOT` → Maven Central snapshots repo).
