### PR TITLE
Support Java datetime value conversion

### DIFF
--- a/src/main/java/com/surrealdb/Array.java
+++ b/src/main/java/com/surrealdb/Array.java
@@ -20,8 +20,10 @@ public class Array extends Native implements Iterable<Value> {
 	 * Creates an Array from a heterogeneous sequence of Java values. Supported
 	 * element types include {@code null}, {@link String}, the boxed numeric types,
 	 * {@link Boolean}, {@link java.math.BigDecimal}, {@link java.util.UUID},
-	 * {@link java.time.Duration}, {@link java.time.ZonedDateTime}, and the
-	 * SurrealDB wrappers {@link Array}, {@link Id}, {@link RecordId}, and
+	 * {@link java.time.Duration}, {@link java.time.Instant},
+	 * {@link java.time.ZonedDateTime}, {@link java.time.OffsetDateTime},
+	 * {@link java.time.LocalDateTime} (interpreted as UTC), {@link java.util.Date},
+	 * and the SurrealDB wrappers {@link Array}, {@link Id}, {@link RecordId}, and
 	 * {@link com.surrealdb.Object}. Unsupported types raise
 	 * {@link IllegalArgumentException}.
 	 * <p>

--- a/src/main/java/com/surrealdb/ValueBoxing.java
+++ b/src/main/java/com/surrealdb/ValueBoxing.java
@@ -2,6 +2,9 @@ package com.surrealdb;
 
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
@@ -52,8 +55,20 @@ final class ValueBoxing {
 		if (e instanceof Duration) {
 			return ValueMut.createDuration((Duration) e);
 		}
+		if (e instanceof Instant) {
+			return ValueMut.createDatetime((Instant) e);
+		}
 		if (e instanceof ZonedDateTime) {
 			return ValueMut.createDatetime((ZonedDateTime) e);
+		}
+		if (e instanceof OffsetDateTime) {
+			return ValueMut.createDatetime((OffsetDateTime) e);
+		}
+		if (e instanceof LocalDateTime) {
+			return ValueMut.createDatetime((LocalDateTime) e);
+		}
+		if (e instanceof java.util.Date) {
+			return ValueMut.createDatetime((java.util.Date) e);
 		}
 		if (e instanceof Array) {
 			return ValueMut.createArray((Array) e);

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -5,6 +5,9 @@ import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -52,6 +55,18 @@ class ValueBuilder {
 		}
 		if (object instanceof ZonedDateTime) {
 			return ValueMut.createDatetime((ZonedDateTime) object);
+		}
+		if (object instanceof OffsetDateTime) {
+			return ValueMut.createDatetime((OffsetDateTime) object);
+		}
+		if (object instanceof LocalDateTime) {
+			return ValueMut.createDatetime((LocalDateTime) object);
+		}
+		if (object instanceof java.util.Date) {
+			return ValueMut.createDatetime((java.util.Date) object);
+		}
+		if (object instanceof Instant) {
+			return ValueMut.createDatetime((Instant) object);
 		}
 		if (object instanceof BigInteger) {
 			throw new SurrealException("Type not supported: " + object.getClass().getCanonicalName());

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -53,6 +53,9 @@ class ValueBuilder {
 		if (object instanceof Duration) {
 			return ValueMut.createDuration((Duration) object);
 		}
+		if (object instanceof Instant) {
+			return ValueMut.createDatetime((Instant) object);
+		}
 		if (object instanceof ZonedDateTime) {
 			return ValueMut.createDatetime((ZonedDateTime) object);
 		}
@@ -64,9 +67,6 @@ class ValueBuilder {
 		}
 		if (object instanceof java.util.Date) {
 			return ValueMut.createDatetime((java.util.Date) object);
-		}
-		if (object instanceof Instant) {
-			return ValueMut.createDatetime((Instant) object);
 		}
 		if (object instanceof BigInteger) {
 			throw new SurrealException("Type not supported: " + object.getClass().getCanonicalName());

--- a/src/main/java/com/surrealdb/ValueClassConverter.java
+++ b/src/main/java/com/surrealdb/ValueClassConverter.java
@@ -6,6 +6,10 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -120,6 +124,24 @@ class ValueClassConverter<T> {
 				return value.getRecordId().getId();
 			}
 			return value.getRecordId();
+		}
+		if (value.isDateTime()) {
+			// Value.getDateTime() returns the datetime at UTC, so LocalDateTime
+			// keeps the same interpretation as the write side (ValueMut).
+			final ZonedDateTime dateTime = value.getDateTime();
+			if (type == Instant.class) {
+				return dateTime.toInstant();
+			}
+			if (type == OffsetDateTime.class) {
+				return dateTime.toOffsetDateTime();
+			}
+			if (type == LocalDateTime.class) {
+				return dateTime.toLocalDateTime();
+			}
+			if (type == java.util.Date.class) {
+				return java.util.Date.from(dateTime.toInstant());
+			}
+			return dateTime;
 		}
 		return convertSingleValue(value);
 	}

--- a/src/main/java/com/surrealdb/ValueClassConverter.java
+++ b/src/main/java/com/surrealdb/ValueClassConverter.java
@@ -141,6 +141,18 @@ class ValueClassConverter<T> {
 			if (type == java.util.Date.class) {
 				return java.util.Date.from(dateTime.toInstant());
 			}
+			// The java.sql types are matched by name first so that runtimes
+			// without the java.sql module never load these classes.
+			final String typeName = type.getName();
+			if ("java.sql.Timestamp".equals(typeName)) {
+				return java.sql.Timestamp.from(dateTime.toInstant());
+			}
+			if ("java.sql.Date".equals(typeName)) {
+				return new java.sql.Date(dateTime.toInstant().toEpochMilli());
+			}
+			if ("java.sql.Time".equals(typeName)) {
+				return new java.sql.Time(dateTime.toInstant().toEpochMilli());
+			}
 			return dateTime;
 		}
 		return convertSingleValue(value);

--- a/src/main/java/com/surrealdb/ValueMut.java
+++ b/src/main/java/com/surrealdb/ValueMut.java
@@ -97,7 +97,8 @@ public class ValueMut extends Native {
 	}
 
 	/**
-	 * Creates a SurrealDB datetime from a local date-time by interpreting it as UTC.
+	 * Creates a SurrealDB datetime from a local date-time by interpreting it as
+	 * UTC.
 	 * <p>
 	 * Prefer {@link Instant}, {@link OffsetDateTime}, or {@link ZonedDateTime} when
 	 * the source value represents an absolute point in time or carries zone/offset
@@ -107,8 +108,21 @@ public class ValueMut extends Native {
 		return createDatetime(d.toInstant(ZoneOffset.UTC));
 	}
 
+	/**
+	 * Creates a SurrealDB datetime from a {@link java.util.Date}.
+	 * <p>
+	 * {@code java.sql.Timestamp} keeps its nanosecond precision.
+	 * {@code java.sql.Date} and {@code java.sql.Time} do not support
+	 * {@link java.util.Date#toInstant()}; they are converted through their
+	 * epoch-millisecond value instead.
+	 */
 	public static ValueMut createDatetime(java.util.Date d) {
-		return createDatetime(d.toInstant());
+		try {
+			return createDatetime(d.toInstant());
+		} catch (UnsupportedOperationException e) {
+			// java.sql.Date and java.sql.Time refuse toInstant()
+			return createDatetime(Instant.ofEpochMilli(d.getTime()));
+		}
 	}
 
 	public static ValueMut createUuid(UUID uuid) {

--- a/src/main/java/com/surrealdb/ValueMut.java
+++ b/src/main/java/com/surrealdb/ValueMut.java
@@ -2,6 +2,10 @@ package com.surrealdb;
 
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -80,8 +84,31 @@ public class ValueMut extends Native {
 		return new ValueMut(newDuration(d.toMillis()));
 	}
 
+	public static ValueMut createDatetime(Instant i) {
+		return new ValueMut(newDatetime(i.getEpochSecond(), i.getNano()));
+	}
+
 	public static ValueMut createDatetime(ZonedDateTime d) {
-		return new ValueMut(newDatetime(d.toEpochSecond(), d.getNano()));
+		return createDatetime(d.toInstant());
+	}
+
+	public static ValueMut createDatetime(OffsetDateTime d) {
+		return createDatetime(d.toInstant());
+	}
+
+	/**
+	 * Creates a SurrealDB datetime from a local date-time by interpreting it as UTC.
+	 * <p>
+	 * Prefer {@link Instant}, {@link OffsetDateTime}, or {@link ZonedDateTime} when
+	 * the source value represents an absolute point in time or carries zone/offset
+	 * information.
+	 */
+	public static ValueMut createDatetime(LocalDateTime d) {
+		return createDatetime(d.toInstant(ZoneOffset.UTC));
+	}
+
+	public static ValueMut createDatetime(java.util.Date d) {
+		return createDatetime(d.toInstant());
 	}
 
 	public static ValueMut createUuid(UUID uuid) {

--- a/src/test/java/com/surrealdb/TypeTests.java
+++ b/src/test/java/com/surrealdb/TypeTests.java
@@ -6,7 +6,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -217,7 +216,7 @@ public class TypeTests {
 	void testArrayOfRejectsUnsupportedType() {
 		try (final Surreal surreal = new Surreal()) {
 			surreal.connect("memory").useNs("test_ns").useDb("test_db");
-			assertThrows(IllegalArgumentException.class, () -> Array.of(new Date()));
+			assertThrows(IllegalArgumentException.class, () -> Array.of(new java.lang.Object()));
 		}
 	}
 

--- a/src/test/java/com/surrealdb/ValueBuilderDateTimeTests.java
+++ b/src/test/java/com/surrealdb/ValueBuilderDateTimeTests.java
@@ -102,6 +102,9 @@ public class ValueBuilderDateTimeTests {
 			dates.offsetDateTime = OffsetDateTime.parse("2026-06-06T10:09:10.123456789+02:00");
 			dates.localDateTime = LocalDateTime.of(2026, 6, 6, 8, 9, 10, 123456789);
 			dates.date = Date.from(Instant.parse("2026-06-06T08:09:10.123Z"));
+			dates.timestamp = java.sql.Timestamp.from(Instant.parse("2026-06-06T08:09:10.123456789Z"));
+			dates.sqlDate = new java.sql.Date(Instant.parse("2026-06-06T08:09:10.123Z").toEpochMilli());
+			dates.sqlTime = new java.sql.Time(Instant.parse("2026-06-06T08:09:10.123Z").toEpochMilli());
 
 			final JavaDates created = surreal.create(JavaDates.class, "java_dates", dates).get(0);
 
@@ -110,6 +113,9 @@ public class ValueBuilderDateTimeTests {
 			assertEquals(dates.offsetDateTime.toInstant(), created.offsetDateTime.toInstant());
 			assertEquals(dates.localDateTime, created.localDateTime);
 			assertEquals(dates.date, created.date);
+			assertEquals(dates.timestamp, created.timestamp);
+			assertEquals(dates.sqlDate, created.sqlDate);
+			assertEquals(dates.sqlTime, created.sqlTime);
 		}
 	}
 

--- a/src/test/java/com/surrealdb/ValueBuilderDateTimeTests.java
+++ b/src/test/java/com/surrealdb/ValueBuilderDateTimeTests.java
@@ -4,12 +4,15 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+
+import com.surrealdb.pojos.JavaDates;
 
 public class ValueBuilderDateTimeTests {
 
@@ -39,6 +42,75 @@ public class ValueBuilderDateTimeTests {
 		final Date date = Date.from(Instant.parse("2026-06-06T08:09:10.123Z"));
 
 		assertBoundValueIsDateTime(date, date.toInstant());
+	}
+
+	@Test
+	void convertZonedDateTimeToDateTime() {
+		final ZonedDateTime dateTime = ZonedDateTime.parse("2026-06-06T10:09:10.123456789+02:00[Europe/Berlin]");
+
+		assertBoundValueIsDateTime(dateTime, dateTime.toInstant());
+	}
+
+	@Test
+	void convertPre1970InstantToDateTime() {
+		final Instant instant = Instant.parse("1969-07-20T20:17:40.123456789Z");
+
+		assertBoundValueIsDateTime(instant, instant);
+	}
+
+	@Test
+	void convertSqlTimestampToDateTimeKeepingNanos() {
+		final java.sql.Timestamp timestamp = java.sql.Timestamp.from(Instant.parse("2026-06-06T08:09:10.123456789Z"));
+
+		assertBoundValueIsDateTime(timestamp, timestamp.toInstant());
+	}
+
+	@Test
+	void convertSqlDateToDateTime() {
+		// java.sql.Date does not support toInstant(); the epoch-millisecond
+		// fallback applies.
+		final java.sql.Date date = new java.sql.Date(Instant.parse("2026-06-06T08:09:10.123Z").toEpochMilli());
+
+		assertBoundValueIsDateTime(date, Instant.ofEpochMilli(date.getTime()));
+	}
+
+	@Test
+	void arrayOfSupportsDateTimeValues() {
+		final Instant instant = Instant.parse("2026-06-06T08:09:10.123456789Z");
+		final ZonedDateTime zonedDateTime = ZonedDateTime.parse("2026-06-06T10:09:10.123456789+02:00[Europe/Berlin]");
+		final OffsetDateTime offsetDateTime = OffsetDateTime.parse("2026-06-06T10:09:10.123456789+02:00");
+		final LocalDateTime localDateTime = LocalDateTime.of(2026, 6, 6, 8, 9, 10, 123456789);
+		final Date date = Date.from(Instant.parse("2026-06-06T08:09:10.123Z"));
+
+		final Array array = Array.of(instant, zonedDateTime, offsetDateTime, localDateTime, date);
+
+		assertEquals(5, array.len());
+		assertEquals(instant, array.get(0).getDateTime().toInstant());
+		assertEquals(zonedDateTime.toInstant(), array.get(1).getDateTime().toInstant());
+		assertEquals(offsetDateTime.toInstant(), array.get(2).getDateTime().toInstant());
+		assertEquals(localDateTime.toInstant(ZoneOffset.UTC), array.get(3).getDateTime().toInstant());
+		assertEquals(date.toInstant(), array.get(4).getDateTime().toInstant());
+	}
+
+	@Test
+	void pojoRoundTripWithJavaDateTimeTypes() {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test").useDb("test");
+
+			final JavaDates dates = new JavaDates();
+			dates.instant = Instant.parse("2026-06-06T08:09:10.123456789Z");
+			dates.offsetDateTime = OffsetDateTime.parse("2026-06-06T10:09:10.123456789+02:00");
+			dates.localDateTime = LocalDateTime.of(2026, 6, 6, 8, 9, 10, 123456789);
+			dates.date = Date.from(Instant.parse("2026-06-06T08:09:10.123Z"));
+
+			final JavaDates created = surreal.create(JavaDates.class, "java_dates", dates).get(0);
+
+			assertEquals(dates.instant, created.instant);
+			// The offset is normalized to UTC; the point in time is preserved.
+			assertEquals(dates.offsetDateTime.toInstant(), created.offsetDateTime.toInstant());
+			assertEquals(dates.localDateTime, created.localDateTime);
+			assertEquals(dates.date, created.date);
+		}
 	}
 
 	private static void assertBoundValueIsDateTime(java.lang.Object input, Instant expected) {

--- a/src/test/java/com/surrealdb/ValueBuilderDateTimeTests.java
+++ b/src/test/java/com/surrealdb/ValueBuilderDateTimeTests.java
@@ -1,0 +1,55 @@
+package com.surrealdb;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+public class ValueBuilderDateTimeTests {
+
+	@Test
+	void convertInstantToDateTime() {
+		final Instant instant = Instant.parse("2026-06-06T08:09:10.123456789Z");
+
+		assertBoundValueIsDateTime(instant, instant);
+	}
+
+	@Test
+	void convertOffsetDateTimeToDateTime() {
+		final OffsetDateTime dateTime = OffsetDateTime.parse("2026-06-06T10:09:10.123456789+02:00");
+
+		assertBoundValueIsDateTime(dateTime, dateTime.toInstant());
+	}
+
+	@Test
+	void convertLocalDateTimeToDateTimeAtUtc() {
+		final LocalDateTime dateTime = LocalDateTime.of(2026, 6, 6, 8, 9, 10, 123456789);
+
+		assertBoundValueIsDateTime(dateTime, dateTime.toInstant(ZoneOffset.UTC));
+	}
+
+	@Test
+	void convertDateToDateTime() {
+		final Date date = Date.from(Instant.parse("2026-06-06T08:09:10.123Z"));
+
+		assertBoundValueIsDateTime(date, date.toInstant());
+	}
+
+	private static void assertBoundValueIsDateTime(java.lang.Object input, Instant expected) {
+		try (Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test").useDb("test");
+
+			final Response response = surreal.query("RETURN $value", Collections.singletonMap("value", input));
+			final Value value = response.take(0);
+
+			assertTrue(value.isDateTime());
+			assertEquals(expected, value.getDateTime().toInstant());
+		}
+	}
+}

--- a/src/test/java/com/surrealdb/pojos/JavaDates.java
+++ b/src/test/java/com/surrealdb/pojos/JavaDates.java
@@ -11,11 +11,14 @@ public class JavaDates {
 	public OffsetDateTime offsetDateTime;
 	public LocalDateTime localDateTime;
 	public Date date;
+	public java.sql.Timestamp timestamp;
+	public java.sql.Date sqlDate;
+	public java.sql.Time sqlTime;
 
 	@Override
 	public String toString() {
 		return "instant: " + instant + ", offsetDateTime: " + offsetDateTime + ", localDateTime: " + localDateTime
-				+ ", date: " + date;
+				+ ", date: " + date + ", timestamp: " + timestamp + ", sqlDate: " + sqlDate + ", sqlTime: " + sqlTime;
 	}
 
 }

--- a/src/test/java/com/surrealdb/pojos/JavaDates.java
+++ b/src/test/java/com/surrealdb/pojos/JavaDates.java
@@ -1,0 +1,21 @@
+package com.surrealdb.pojos;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.Date;
+
+public class JavaDates {
+
+	public Instant instant;
+	public OffsetDateTime offsetDateTime;
+	public LocalDateTime localDateTime;
+	public Date date;
+
+	@Override
+	public String toString() {
+		return "instant: " + instant + ", offsetDateTime: " + offsetDateTime + ", localDateTime: " + localDateTime
+				+ ", date: " + date;
+	}
+
+}


### PR DESCRIPTION
## Summary

- Add `ValueBuilder` conversion support for `Instant`, `OffsetDateTime`, `LocalDateTime`, and `java.util.Date`
- Route datetime creation through `Instant` so native datetime values receive consistent epoch seconds and nanoseconds
- Accept the same datetime types as `Array.of(...)` / `Id.from(...)` elements (`ValueBoxing`)
- Deserialize datetime values into `Instant`, `OffsetDateTime`, `LocalDateTime`, `java.util.Date`, `java.sql.Timestamp`, `java.sql.Date`, and `java.sql.Time` POJO/record fields (`ValueClassConverter`), so the new types round-trip
- Convert `java.sql.Date` and `java.sql.Time` through their epoch-millisecond value, since their `toInstant()` throws `UnsupportedOperationException`; `java.sql.Timestamp` keeps its nanosecond precision
- Add regression tests covering public query binding for each newly supported datetime type, `ZonedDateTime` backward compatibility, pre-1970 instants, the `java.sql` types, `Array.of` boxing, and a POJO round-trip

## Testing

- `./gradlew test` (full suite; `ConnectionTests.connectWebsocket` requires a SurrealDB server at `ws://localhost:8000`)
- `./gradlew spotlessCheck`

## Docs

Companion docs PR: surrealdb/docs#1797

Closes #169
