### PR TITLE
Add @SurrealName field mapping support

### DIFF
--- a/src/main/java/com/surrealdb/SurrealFieldNames.java
+++ b/src/main/java/com/surrealdb/SurrealFieldNames.java
@@ -3,7 +3,9 @@ package com.surrealdb;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 final class SurrealFieldNames {
 
@@ -39,29 +41,28 @@ final class SurrealFieldNames {
 
 	static Map<String, Field> inheritedFieldsBySurrealName(final Class<?> clazz) {
 		final Map<String, Field> fields = new HashMap<>();
+		final Set<String> seenJavaNames = new HashSet<>();
 		Class<?> c = clazz;
 		while (c != null && c != java.lang.Object.class) {
 			for (final Field field : c.getDeclaredFields()) {
 				if (!isSerializableField(field)) {
 					continue;
 				}
+				// Java field hiding is based on the declared Java name, not the
+				// resolved SurrealDB name. Keep hidden superclass fields out even
+				// when the subclass field is annotated to a different key.
+				if (!seenJavaNames.add(field.getName())) {
+					continue;
+				}
 				final String name = nameFor(field);
-				// Preserve existing field-hiding behavior for unannotated raw names:
-				// the concrete class wins over a same-named superclass field.
-				if (fields.containsKey(name) && !isPlainRawName(field, name)) {
+				if (fields.containsKey(name)) {
 					throw duplicateName(name, fields.get(name), field);
 				}
-				if (!fields.containsKey(name)) {
-					fields.put(name, field);
-				}
+				fields.put(name, field);
 			}
 			c = c.getSuperclass();
 		}
 		return fields;
-	}
-
-	private static boolean isPlainRawName(final Field field, final String name) {
-		return field.getAnnotation(SurrealName.class) == null && field.getName().equals(name);
 	}
 
 	private static void putUnique(final Map<String, Field> fields, final String name, final Field field) {

--- a/src/main/java/com/surrealdb/SurrealFieldNames.java
+++ b/src/main/java/com/surrealdb/SurrealFieldNames.java
@@ -29,6 +29,15 @@ final class SurrealFieldNames {
 		return value;
 	}
 
+	static boolean hasDeclaredSurrealName(final Field[] fields) {
+		for (final Field field : fields) {
+			if (isSerializableField(field) && field.getAnnotation(SurrealName.class) != null) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	static void ensureUniqueDeclaredNames(final Class<?> clazz) {
 		final Map<String, Field> fields = new HashMap<>();
 		for (final Field field : clazz.getDeclaredFields()) {

--- a/src/main/java/com/surrealdb/SurrealFieldNames.java
+++ b/src/main/java/com/surrealdb/SurrealFieldNames.java
@@ -1,0 +1,82 @@
+package com.surrealdb;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+final class SurrealFieldNames {
+
+	private SurrealFieldNames() {
+	}
+
+	static boolean isSerializableField(final Field field) {
+		final int mods = field.getModifiers();
+		return !Modifier.isStatic(mods) && !Modifier.isTransient(mods);
+	}
+
+	static String nameFor(final Field field) {
+		final SurrealName name = field.getAnnotation(SurrealName.class);
+		if (name == null) {
+			return field.getName();
+		}
+		final String value = name.value();
+		if (value == null || value.trim().isEmpty()) {
+			throw new SurrealException("@SurrealName value must not be blank on " + describe(field));
+		}
+		return value;
+	}
+
+	static void ensureUniqueDeclaredNames(final Class<?> clazz) {
+		final Map<String, Field> fields = new HashMap<>();
+		for (final Field field : clazz.getDeclaredFields()) {
+			if (!isSerializableField(field)) {
+				continue;
+			}
+			putUnique(fields, nameFor(field), field);
+		}
+	}
+
+	static Map<String, Field> inheritedFieldsBySurrealName(final Class<?> clazz) {
+		final Map<String, Field> fields = new HashMap<>();
+		Class<?> c = clazz;
+		while (c != null && c != java.lang.Object.class) {
+			for (final Field field : c.getDeclaredFields()) {
+				if (!isSerializableField(field)) {
+					continue;
+				}
+				final String name = nameFor(field);
+				// Preserve existing field-hiding behavior for unannotated raw names:
+				// the concrete class wins over a same-named superclass field.
+				if (fields.containsKey(name) && !isPlainRawName(field, name)) {
+					throw duplicateName(name, fields.get(name), field);
+				}
+				if (!fields.containsKey(name)) {
+					fields.put(name, field);
+				}
+			}
+			c = c.getSuperclass();
+		}
+		return fields;
+	}
+
+	private static boolean isPlainRawName(final Field field, final String name) {
+		return field.getAnnotation(SurrealName.class) == null && field.getName().equals(name);
+	}
+
+	private static void putUnique(final Map<String, Field> fields, final String name, final Field field) {
+		final Field previous = fields.put(name, field);
+		if (previous != null) {
+			throw duplicateName(name, previous, field);
+		}
+	}
+
+	private static SurrealException duplicateName(final String name, final Field first, final Field second) {
+		return new SurrealException(
+				"Duplicate SurrealDB field name '" + name + "' on " + describe(first) + " and " + describe(second));
+	}
+
+	private static String describe(final Field field) {
+		return field.getDeclaringClass().getName() + "." + field.getName();
+	}
+}

--- a/src/main/java/com/surrealdb/SurrealName.java
+++ b/src/main/java/com/surrealdb/SurrealName.java
@@ -1,0 +1,26 @@
+package com.surrealdb;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Overrides the SurrealDB object key used when converting a Java field.
+ *
+ * <p>
+ * Unannotated fields keep the historical behavior and use the Java field name.
+ * For records, annotate the record component; the field-target annotation is
+ * available on the generated backing field used by the converter.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface SurrealName {
+
+	/**
+	 * The SurrealDB object key to use for this field.
+	 *
+	 * @return a non-blank SurrealDB object key
+	 */
+	String value();
+}

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -101,14 +101,17 @@ class ValueBuilder {
 		}
 		final Field[] fields = object.getClass().getDeclaredFields();
 		if (fields.length > 0) {
-			SurrealFieldNames.ensureUniqueDeclaredNames(object.getClass());
+			final boolean hasSurrealName = SurrealFieldNames.hasDeclaredSurrealName(fields);
+			if (hasSurrealName) {
+				SurrealFieldNames.ensureUniqueDeclaredNames(object.getClass());
+			}
 			final List<EntryMut> entries = new ArrayList<>(fields.length);
 			for (final Field field : fields) {
 				if (!SurrealFieldNames.isSerializableField(field)) {
 					continue;
 				}
 				field.setAccessible(true);
-				final String name = SurrealFieldNames.nameFor(field);
+				final String name = hasSurrealName ? SurrealFieldNames.nameFor(field) : field.getName();
 				final java.lang.Object value = field.get(object);
 				if (value != null) {
 					entries.add(EntryMut.newEntry(name, convert(value)));

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -1,7 +1,6 @@
 package com.surrealdb;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
@@ -102,14 +101,14 @@ class ValueBuilder {
 		}
 		final Field[] fields = object.getClass().getDeclaredFields();
 		if (fields.length > 0) {
+			SurrealFieldNames.ensureUniqueDeclaredNames(object.getClass());
 			final List<EntryMut> entries = new ArrayList<>(fields.length);
 			for (final Field field : fields) {
-				int mods = field.getModifiers();
-				if (Modifier.isStatic(mods) || Modifier.isTransient(mods)) {
+				if (!SurrealFieldNames.isSerializableField(field)) {
 					continue;
 				}
 				field.setAccessible(true);
-				final String name = field.getName();
+				final String name = SurrealFieldNames.nameFor(field);
 				final java.lang.Object value = field.get(object);
 				if (value != null) {
 					entries.add(EntryMut.newEntry(name, convert(value)));

--- a/src/main/java/com/surrealdb/ValueClassConverter.java
+++ b/src/main/java/com/surrealdb/ValueClassConverter.java
@@ -258,21 +258,22 @@ class ValueClassConverter<T> {
 		}
 		final T target = clazz.getConstructor().newInstance();
 		initOptionalFields(clazz, target);
+		final Map<String, Field> fields = SurrealFieldNames.inheritedFieldsBySurrealName(clazz);
 		for (final Entry entry : source) {
-			try {
-				final String key = entry.getKey();
-				final Value value = entry.getValue();
-				final Field field = getInheritedDeclaredField(clazz, key);
-				field.setAccessible(true);
-				final java.lang.Object converted = convertValueToType(value, field.getType(), field.getGenericType());
-				if (converted == null && field.getType().isPrimitive()) {
-					// Leave primitive fields at their default value; setting null would throw.
-					continue;
-				}
-				field.set(target, converted);
-			} catch (NoSuchFieldException e) {
+			final String key = entry.getKey();
+			final Value value = entry.getValue();
+			final Field field = fields.get(key);
+			if (field == null) {
 				// Safe to ignore: source has a key with no matching field.
+				continue;
 			}
+			field.setAccessible(true);
+			final java.lang.Object converted = convertValueToType(value, field.getType(), field.getGenericType());
+			if (converted == null && field.getType().isPrimitive()) {
+				// Leave primitive fields at their default value; setting null would throw.
+				continue;
+			}
+			field.set(target, converted);
 		}
 		return target;
 	}
@@ -290,10 +291,12 @@ class ValueClassConverter<T> {
 		final Type[] genericTypes = new Type[count];
 		for (int i = 0; i < count; i++) {
 			final java.lang.Object rc = componentsArray[i];
-			names[i] = (String) RC_GET_NAME.invoke(rc);
+			final String componentName = (String) RC_GET_NAME.invoke(rc);
+			names[i] = recordComponentSurrealName(clazz, componentName);
 			types[i] = (Class<?>) RC_GET_TYPE.invoke(rc);
 			genericTypes[i] = (Type) RC_GET_GENERIC_TYPE.invoke(rc);
 		}
+		ensureUniqueRecordComponentNames(clazz, names);
 
 		// Build a lookup of incoming entries keyed by name.
 		final Map<String, Value> entries = new HashMap<>();
@@ -320,6 +323,21 @@ class ValueClassConverter<T> {
 		final Constructor<T> ctor = clazz.getDeclaredConstructor(types);
 		ctor.setAccessible(true);
 		return ctor.newInstance(args);
+	}
+
+	private static String recordComponentSurrealName(final Class<?> clazz, final String componentName)
+			throws NoSuchFieldException {
+		return SurrealFieldNames.nameFor(clazz.getDeclaredField(componentName));
+	}
+
+	private static void ensureUniqueRecordComponentNames(final Class<?> clazz, final String[] names) {
+		final Map<String, Boolean> seen = new HashMap<>();
+		for (final String name : names) {
+			if (seen.put(name, Boolean.TRUE) != null) {
+				throw new SurrealException(
+						"Duplicate SurrealDB field name '" + name + "' on record " + clazz.getName());
+			}
+		}
 	}
 
 	private static java.lang.Object defaultForRecordComponent(final Class<?> type) {
@@ -364,17 +382,6 @@ class ValueClassConverter<T> {
 			}
 			c = c.getSuperclass();
 		}
-	}
-
-	static Field getInheritedDeclaredField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
-		while (clazz != null) {
-			try {
-				return clazz.getDeclaredField(fieldName);
-			} catch (NoSuchFieldException e) {
-				clazz = clazz.getSuperclass();
-			}
-		}
-		throw new NoSuchFieldException("Field '" + fieldName + "' not found in class hierarchy.");
 	}
 
 	final T convert(final Value value) {

--- a/src/recordTest/java/com/surrealdb/SurrealNameRecordTests.java
+++ b/src/recordTest/java/com/surrealdb/SurrealNameRecordTests.java
@@ -29,7 +29,7 @@ public class SurrealNameRecordTests {
 	void serializesRecordComponentsUsingSurrealNames() {
 		try (final Surreal surreal = openMemoryDatabase()) {
 			final AnnotatedRecord record = new AnnotatedRecord("Ada", 7, "ace");
-			final Value value = surreal.queryBind("RETURN $record", Collections.singletonMap("record", record)).take(0);
+			final Value value = surreal.query("RETURN $record", Collections.singletonMap("record", record)).take(0);
 
 			assertEquals(Arrays.asList("first_name", "login_count", "nickname"), keys(value.getObject()));
 		}
@@ -38,7 +38,7 @@ public class SurrealNameRecordTests {
 	@Test
 	void deserializesRecordComponentsFromSurrealNames() {
 		try (final Surreal surreal = openMemoryDatabase()) {
-			final Value value = surreal.queryBind("RETURN $record", Collections.singletonMap("record", annotatedMap()))
+			final Value value = surreal.query("RETURN $record", Collections.singletonMap("record", annotatedMap()))
 					.take(0);
 
 			assertEquals(new AnnotatedRecord("Grace", 11, "g"), value.get(AnnotatedRecord.class));
@@ -51,7 +51,7 @@ public class SurrealNameRecordTests {
 			final Map<String, java.lang.Object> values = annotatedMap();
 			values.put("firstName", "Raw");
 			values.put("loginCount", 1);
-			final Value value = surreal.queryBind("RETURN $record", Collections.singletonMap("record", values)).take(0);
+			final Value value = surreal.query("RETURN $record", Collections.singletonMap("record", values)).take(0);
 
 			assertEquals(new AnnotatedRecord("Grace", 11, "g"), value.get(AnnotatedRecord.class));
 		}
@@ -61,7 +61,7 @@ public class SurrealNameRecordTests {
 	void rejectsDuplicateSurrealNamesForRecords() {
 		try (final Surreal surreal = openMemoryDatabase()) {
 			final Value value = surreal
-					.queryBind("RETURN $record",
+					.query("RETURN $record",
 							Collections.singletonMap("record", Collections.singletonMap("duplicated_name", "value")))
 					.take(0);
 
@@ -72,7 +72,7 @@ public class SurrealNameRecordTests {
 	@Test
 	void rejectsBlankSurrealNamesForRecords() {
 		try (final Surreal surreal = openMemoryDatabase()) {
-			final Value value = surreal.queryBind("RETURN $record",
+			final Value value = surreal.query("RETURN $record",
 					Collections.singletonMap("record", Collections.singletonMap("firstName", "Ada"))).take(0);
 
 			assertThrows(SurrealException.class, () -> value.get(BlankNameRecord.class));
@@ -83,7 +83,7 @@ public class SurrealNameRecordTests {
 	void keepsRawRecordComponentNamesForUnannotatedComponents() {
 		try (final Surreal surreal = openMemoryDatabase()) {
 			final Value value = surreal
-					.queryBind("RETURN $record", Collections.singletonMap("record", new RawRecord("Ada", 7))).take(0);
+					.query("RETURN $record", Collections.singletonMap("record", new RawRecord("Ada", 7))).take(0);
 			final List<String> keys = keys(value.getObject());
 
 			assertEquals(Arrays.asList("firstName", "loginCount"), keys);

--- a/src/recordTest/java/com/surrealdb/SurrealNameRecordTests.java
+++ b/src/recordTest/java/com/surrealdb/SurrealNameRecordTests.java
@@ -1,0 +1,120 @@
+package com.surrealdb;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+public class SurrealNameRecordTests {
+
+	public record AnnotatedRecord(@SurrealName("first_name") String firstName,
+			@SurrealName("login_count") int loginCount, String nickname) {
+	}
+
+	public record DuplicateRecord(@SurrealName("duplicated_name") String firstName,
+			@SurrealName("duplicated_name") String secondName) {
+	}
+
+	public record BlankNameRecord(@SurrealName(" ") String firstName) {
+	}
+
+	@Test
+	void serializesRecordComponentsUsingSurrealNames() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final AnnotatedRecord record = new AnnotatedRecord("Ada", 7, "ace");
+			final Value value = surreal.queryBind("RETURN $record", Collections.singletonMap("record", record)).take(0);
+
+			assertEquals(Arrays.asList("first_name", "login_count", "nickname"), keys(value.getObject()));
+		}
+	}
+
+	@Test
+	void deserializesRecordComponentsFromSurrealNames() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Value value = surreal.queryBind("RETURN $record", Collections.singletonMap("record", annotatedMap()))
+					.take(0);
+
+			assertEquals(new AnnotatedRecord("Grace", 11, "g"), value.get(AnnotatedRecord.class));
+		}
+	}
+
+	@Test
+	void annotatedRecordComponentsDoNotAlsoAcceptRawNames() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Map<String, java.lang.Object> values = annotatedMap();
+			values.put("firstName", "Raw");
+			values.put("loginCount", 1);
+			final Value value = surreal.queryBind("RETURN $record", Collections.singletonMap("record", values)).take(0);
+
+			assertEquals(new AnnotatedRecord("Grace", 11, "g"), value.get(AnnotatedRecord.class));
+		}
+	}
+
+	@Test
+	void rejectsDuplicateSurrealNamesForRecords() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Value value = surreal
+					.queryBind("RETURN $record",
+							Collections.singletonMap("record", Collections.singletonMap("duplicated_name", "value")))
+					.take(0);
+
+			assertThrows(SurrealException.class, () -> value.get(DuplicateRecord.class));
+		}
+	}
+
+	@Test
+	void rejectsBlankSurrealNamesForRecords() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Value value = surreal.queryBind("RETURN $record",
+					Collections.singletonMap("record", Collections.singletonMap("firstName", "Ada"))).take(0);
+
+			assertThrows(SurrealException.class, () -> value.get(BlankNameRecord.class));
+		}
+	}
+
+	@Test
+	void keepsRawRecordComponentNamesForUnannotatedComponents() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Value value = surreal
+					.queryBind("RETURN $record", Collections.singletonMap("record", new RawRecord("Ada", 7))).take(0);
+			final List<String> keys = keys(value.getObject());
+
+			assertEquals(Arrays.asList("firstName", "loginCount"), keys);
+			assertFalse(keys.contains("first_name"));
+			assertFalse(keys.contains("login_count"));
+		}
+	}
+
+	public record RawRecord(String firstName, int loginCount) {
+	}
+
+	private static Surreal openMemoryDatabase() {
+		final Surreal surreal = new Surreal();
+		surreal.connect("memory").useNs("surreal_name_record_tests").useDb("surreal_name_record_tests");
+		return surreal;
+	}
+
+	private static Map<String, java.lang.Object> annotatedMap() {
+		final Map<String, java.lang.Object> values = new LinkedHashMap<>();
+		values.put("first_name", "Grace");
+		values.put("login_count", 11);
+		values.put("nickname", "g");
+		return values;
+	}
+
+	private static List<String> keys(final Object object) {
+		final List<String> keys = new ArrayList<>();
+		for (final Entry entry : object) {
+			keys.add(entry.getKey());
+		}
+		Collections.sort(keys);
+		return keys;
+	}
+}

--- a/src/test/java/com/surrealdb/SurrealNameTests.java
+++ b/src/test/java/com/surrealdb/SurrealNameTests.java
@@ -1,0 +1,334 @@
+package com.surrealdb;
+
+import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+public class SurrealNameTests {
+
+	private static final ZonedDateTime CREATED_AT = ZonedDateTime.of(2026, 6, 6, 12, 30, 0, 0, ZoneId.of("UTC"));
+	private static final ZonedDateTime RAW_CREATED_AT = ZonedDateTime.of(1999, 1, 2, 3, 4, 5, 0, ZoneId.of("UTC"));
+
+	public static final class AnnotatedProfile {
+
+		@SurrealName("first_name")
+		private String firstName;
+
+		@SurrealName("created_at")
+		private ZonedDateTime createdAt;
+
+		@SurrealName("login_count")
+		private int loginCount;
+
+		@SurrealName("active_flag")
+		private boolean activeFlag;
+
+		@SurrealName("credit_limit")
+		private BigDecimal creditLimit;
+
+		@SurrealName("tag_names")
+		private List<String> tagNames;
+
+		@SurrealName("optional_note")
+		private Optional<String> optionalNote;
+
+		private String nickname;
+
+		public AnnotatedProfile() {
+		}
+
+		AnnotatedProfile(String firstName, ZonedDateTime createdAt, int loginCount, boolean activeFlag,
+				BigDecimal creditLimit, List<String> tagNames, Optional<String> optionalNote, String nickname) {
+			this.firstName = firstName;
+			this.createdAt = createdAt;
+			this.loginCount = loginCount;
+			this.activeFlag = activeFlag;
+			this.creditLimit = creditLimit;
+			this.tagNames = tagNames;
+			this.optionalNote = optionalNote;
+			this.nickname = nickname;
+		}
+	}
+
+	public static final class RawNameProfile {
+		private String firstName;
+		private ZonedDateTime createdAt;
+		private int loginCount;
+		private boolean activeFlag;
+		private BigDecimal creditLimit;
+		private List<String> tagNames;
+		private Optional<String> optionalNote;
+
+		public RawNameProfile() {
+		}
+	}
+
+	public static final class IgnoredMembersProfile {
+		@SurrealName("instance_name")
+		private String instanceName;
+
+		@SurrealName("cached_name")
+		private static String cachedName = "must not serialize";
+
+		@SurrealName("temporary_name")
+		private transient String temporaryName;
+
+		IgnoredMembersProfile(String instanceName, String temporaryName) {
+			this.instanceName = instanceName;
+			this.temporaryName = temporaryName;
+		}
+	}
+
+	public static final class DuplicateSurrealNameProfile {
+		@SurrealName("duplicated_name")
+		private String firstName = "first";
+
+		@SurrealName("duplicated_name")
+		private String secondName = "second";
+
+		public DuplicateSurrealNameProfile() {
+		}
+	}
+
+	public static final class BlankSurrealNameProfile {
+		@SurrealName(" ")
+		private String firstName = "Ada";
+
+		public BlankSurrealNameProfile() {
+		}
+	}
+
+	@Test
+	void serializesAnnotatedFieldsUsingSurrealNames() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", profile()))
+					.take(0);
+			final List<String> keys = keys(value.getObject());
+
+			assertEquals(Arrays.asList("active_flag", "created_at", "credit_limit", "first_name", "login_count",
+					"nickname", "optional_note", "tag_names"), keys);
+			assertFalse(keys.contains("activeFlag"));
+			assertFalse(keys.contains("createdAt"));
+			assertFalse(keys.contains("creditLimit"));
+			assertFalse(keys.contains("firstName"));
+			assertFalse(keys.contains("loginCount"));
+			assertFalse(keys.contains("optionalNote"));
+			assertFalse(keys.contains("tagNames"));
+		}
+	}
+
+	@Test
+	void deserializesAnnotatedFieldsFromSurrealNames() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Value value = surreal
+					.queryBind("RETURN $profile", Collections.singletonMap("profile", annotatedMap())).take(0);
+
+			assertAnnotatedProfile(value.get(AnnotatedProfile.class), "Grace", CREATED_AT, 11, true,
+					new BigDecimal("999.50"), Arrays.asList("snake", "case"), Optional.of("read from explicit name"),
+					"g");
+		}
+	}
+
+	@Test
+	void explicitSurrealNameWinsWhenRawAndExplicitKeysAreBothPresent() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Map<String, java.lang.Object> values = annotatedMap();
+			values.put("firstName", "Raw");
+			values.put("createdAt", RAW_CREATED_AT);
+			values.put("loginCount", 1);
+			values.put("activeFlag", false);
+			values.put("creditLimit", new BigDecimal("1.00"));
+			values.put("tagNames", Collections.singletonList("raw"));
+			values.put("optionalNote", "raw note");
+			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", values))
+					.take(0);
+
+			assertAnnotatedProfile(value.get(AnnotatedProfile.class), "Grace", CREATED_AT, 11, true,
+					new BigDecimal("999.50"), Arrays.asList("snake", "case"), Optional.of("read from explicit name"),
+					"g");
+		}
+	}
+
+	@Test
+	void roundTripsAnnotatedObjectThroughCreateAndSelectUsingSurrealNames() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final AnnotatedProfile created = surreal.create(AnnotatedProfile.class, "annotated_profile", profile())
+					.get(0);
+			assertAnnotatedProfile(created, "Ada", CREATED_AT, 7, true, new BigDecimal("123.45"),
+					Arrays.asList("admin", "beta"), Optional.of("explicitly named"), "ace");
+
+			final Value selected = surreal.query("SELECT * FROM annotated_profile").take(0).getArray().get(0);
+			final List<String> keys = keys(selected.getObject());
+			assertTrue(keys.contains("first_name"));
+			assertTrue(keys.contains("created_at"));
+			assertTrue(keys.contains("login_count"));
+			assertTrue(keys.contains("active_flag"));
+			assertTrue(keys.contains("credit_limit"));
+			assertTrue(keys.contains("tag_names"));
+			assertTrue(keys.contains("optional_note"));
+			assertTrue(keys.contains("nickname"));
+			assertFalse(keys.contains("firstName"));
+			assertFalse(keys.contains("createdAt"));
+			assertFalse(keys.contains("loginCount"));
+			assertFalse(keys.contains("activeFlag"));
+			assertFalse(keys.contains("creditLimit"));
+			assertFalse(keys.contains("tagNames"));
+			assertFalse(keys.contains("optionalNote"));
+		}
+	}
+
+	@Test
+	void keepsRawFieldNameBehaviorForUnannotatedFields() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", rawNameMap()))
+					.take(0);
+			final RawNameProfile profile = value.get(RawNameProfile.class);
+
+			assertEquals("Ada", profile.firstName);
+			assertEquals(CREATED_AT, profile.createdAt);
+			assertEquals(7, profile.loginCount);
+			assertTrue(profile.activeFlag);
+			assertEquals(0, new BigDecimal("123.45").compareTo(profile.creditLimit));
+			assertEquals(Arrays.asList("admin", "beta"), profile.tagNames);
+			assertEquals(Optional.of("raw names remain supported"), profile.optionalNote);
+		}
+	}
+
+	@Test
+	void keepsIgnoringUnknownDatabaseKeysForAnnotatedTypes() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Map<String, java.lang.Object> values = annotatedMap();
+			values.put("unknown_name", "ignored");
+			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", values))
+					.take(0);
+
+			assertAnnotatedProfile(value.get(AnnotatedProfile.class), "Grace", CREATED_AT, 11, true,
+					new BigDecimal("999.50"), Arrays.asList("snake", "case"), Optional.of("read from explicit name"),
+					"g");
+		}
+	}
+
+	@Test
+	void keepsIgnoringStaticAndTransientFieldsEvenWhenAnnotated() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final IgnoredMembersProfile profile = new IgnoredMembersProfile("persisted", "temporary");
+			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", profile))
+					.take(0);
+			final List<String> keys = keys(value.getObject());
+
+			assertEquals(Collections.singletonList("instance_name"), keys);
+		}
+	}
+
+	@Test
+	void rejectsDuplicateSurrealNamesDuringSerialization() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			assertThrows(SurrealException.class, () -> surreal.queryBind("RETURN $profile",
+					Collections.singletonMap("profile", new DuplicateSurrealNameProfile())));
+		}
+	}
+
+	@Test
+	void rejectsDuplicateSurrealNamesDuringDeserialization() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Value value = surreal
+					.queryBind("RETURN $profile",
+							Collections.singletonMap("profile", Collections.singletonMap("duplicated_name", "value")))
+					.take(0);
+
+			assertThrows(SurrealException.class, () -> value.get(DuplicateSurrealNameProfile.class));
+		}
+	}
+
+	@Test
+	void rejectsBlankSurrealNameDuringSerialization() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			assertThrows(SurrealException.class, () -> surreal.queryBind("RETURN $profile",
+					Collections.singletonMap("profile", new BlankSurrealNameProfile())));
+		}
+	}
+
+	@Test
+	void rejectsBlankSurrealNameDuringDeserialization() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Value value = surreal.queryBind("RETURN $profile",
+					Collections.singletonMap("profile", Collections.singletonMap("firstName", "Ada"))).take(0);
+
+			assertThrows(SurrealException.class, () -> value.get(BlankSurrealNameProfile.class));
+		}
+	}
+
+	private static Surreal openMemoryDatabase() {
+		final Surreal surreal = new Surreal();
+		surreal.connect("memory").useNs("surreal_name_tests").useDb("surreal_name_tests");
+		return surreal;
+	}
+
+	private static AnnotatedProfile profile() {
+		return new AnnotatedProfile("Ada", CREATED_AT, 7, true, new BigDecimal("123.45"),
+				Arrays.asList("admin", "beta"), Optional.of("explicitly named"), "ace");
+	}
+
+	private static Map<String, java.lang.Object> annotatedMap() {
+		final Map<String, java.lang.Object> values = new LinkedHashMap<>();
+		values.put("first_name", "Grace");
+		values.put("created_at", CREATED_AT);
+		values.put("login_count", 11);
+		values.put("active_flag", true);
+		values.put("credit_limit", new BigDecimal("999.50"));
+		values.put("tag_names", Arrays.asList("snake", "case"));
+		values.put("optional_note", "read from explicit name");
+		values.put("nickname", "g");
+		return values;
+	}
+
+	private static Map<String, java.lang.Object> rawNameMap() {
+		final Map<String, java.lang.Object> values = new LinkedHashMap<>();
+		values.put("firstName", "Ada");
+		values.put("createdAt", CREATED_AT);
+		values.put("loginCount", 7);
+		values.put("activeFlag", true);
+		values.put("creditLimit", new BigDecimal("123.45"));
+		values.put("tagNames", Arrays.asList("admin", "beta"));
+		values.put("optionalNote", "raw names remain supported");
+		return values;
+	}
+
+	private static List<String> keys(final Object object) {
+		final List<String> keys = new ArrayList<>();
+		for (final Entry entry : object) {
+			keys.add(entry.getKey());
+		}
+		Collections.sort(keys);
+		return keys;
+	}
+
+	private static void assertAnnotatedProfile(final AnnotatedProfile actual, final String firstName,
+			final ZonedDateTime createdAt, final int loginCount, final boolean activeFlag, final BigDecimal creditLimit,
+			final List<String> tagNames, final Optional<String> optionalNote, final String nickname) {
+		assertNotNull(actual);
+		assertEquals(firstName, actual.firstName);
+		assertEquals(createdAt, actual.createdAt);
+		assertEquals(loginCount, actual.loginCount);
+		assertEquals(activeFlag, actual.activeFlag);
+		assertNotNull(actual.creditLimit);
+		assertEquals(0, creditLimit.compareTo(actual.creditLimit));
+		assertEquals(tagNames, actual.tagNames);
+		assertEquals(optionalNote, actual.optionalNote);
+		assertEquals(nickname, actual.nickname);
+	}
+}

--- a/src/test/java/com/surrealdb/SurrealNameTests.java
+++ b/src/test/java/com/surrealdb/SurrealNameTests.java
@@ -94,6 +94,15 @@ public class SurrealNameTests {
 		}
 	}
 
+	public static final class IgnoredMembersReadProfile {
+		private String instanceName;
+		private static String cachedName;
+		private transient String temporaryName;
+
+		public IgnoredMembersReadProfile() {
+		}
+	}
+
 	public static final class DuplicateSurrealNameProfile {
 		@SurrealName("duplicated_name")
 		private String firstName = "first";
@@ -131,7 +140,7 @@ public class SurrealNameTests {
 	@Test
 	void serializesAnnotatedFieldsUsingSurrealNames() {
 		try (final Surreal surreal = openMemoryDatabase()) {
-			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", profile()))
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", profile()))
 					.take(0);
 			final List<String> keys = keys(value.getObject());
 
@@ -150,8 +159,8 @@ public class SurrealNameTests {
 	@Test
 	void deserializesAnnotatedFieldsFromSurrealNames() {
 		try (final Surreal surreal = openMemoryDatabase()) {
-			final Value value = surreal
-					.queryBind("RETURN $profile", Collections.singletonMap("profile", annotatedMap())).take(0);
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", annotatedMap()))
+					.take(0);
 
 			assertAnnotatedProfile(value.get(AnnotatedProfile.class), "Grace", CREATED_AT, 11, true,
 					new BigDecimal("999.50"), Arrays.asList("snake", "case"), Optional.of("read from explicit name"),
@@ -170,8 +179,7 @@ public class SurrealNameTests {
 			values.put("creditLimit", new BigDecimal("1.00"));
 			values.put("tagNames", Collections.singletonList("raw"));
 			values.put("optionalNote", "raw note");
-			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", values))
-					.take(0);
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", values)).take(0);
 
 			assertAnnotatedProfile(value.get(AnnotatedProfile.class), "Grace", CREATED_AT, 11, true,
 					new BigDecimal("999.50"), Arrays.asList("snake", "case"), Optional.of("read from explicit name"),
@@ -185,8 +193,7 @@ public class SurrealNameTests {
 			final Map<String, java.lang.Object> values = new LinkedHashMap<>();
 			values.put("id", "raw id must not populate hidden superclass field");
 			values.put("child_id", "child");
-			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", values))
-					.take(0);
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", values)).take(0);
 
 			final HiddenChildProfile profile = value.get(HiddenChildProfile.class);
 			assertEquals("child", profile.id);
@@ -225,7 +232,7 @@ public class SurrealNameTests {
 	@Test
 	void keepsRawFieldNameBehaviorForUnannotatedFields() {
 		try (final Surreal surreal = openMemoryDatabase()) {
-			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", rawNameMap()))
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", rawNameMap()))
 					.take(0);
 			final RawNameProfile profile = value.get(RawNameProfile.class);
 
@@ -244,8 +251,7 @@ public class SurrealNameTests {
 		try (final Surreal surreal = openMemoryDatabase()) {
 			final Map<String, java.lang.Object> values = annotatedMap();
 			values.put("unknown_name", "ignored");
-			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", values))
-					.take(0);
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", values)).take(0);
 
 			assertAnnotatedProfile(value.get(AnnotatedProfile.class), "Grace", CREATED_AT, 11, true,
 					new BigDecimal("999.50"), Arrays.asList("snake", "case"), Optional.of("read from explicit name"),
@@ -257,8 +263,7 @@ public class SurrealNameTests {
 	void keepsIgnoringStaticAndTransientFieldsEvenWhenAnnotated() {
 		try (final Surreal surreal = openMemoryDatabase()) {
 			final IgnoredMembersProfile profile = new IgnoredMembersProfile("persisted", "temporary");
-			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", profile))
-					.take(0);
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", profile)).take(0);
 			final List<String> keys = keys(value.getObject());
 
 			assertEquals(Collections.singletonList("instance_name"), keys);
@@ -266,9 +271,26 @@ public class SurrealNameTests {
 	}
 
 	@Test
+	void keepsStaticAndTransientFieldsUntouchedDuringDeserialization() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			IgnoredMembersReadProfile.cachedName = "untouched";
+			final Map<String, java.lang.Object> values = new LinkedHashMap<>();
+			values.put("instanceName", "persisted");
+			values.put("cachedName", "from database");
+			values.put("temporaryName", "from database");
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", values)).take(0);
+
+			final IgnoredMembersReadProfile profile = value.get(IgnoredMembersReadProfile.class);
+			assertEquals("persisted", profile.instanceName);
+			assertEquals("untouched", IgnoredMembersReadProfile.cachedName);
+			assertNull(profile.temporaryName);
+		}
+	}
+
+	@Test
 	void rejectsDuplicateSurrealNamesDuringSerialization() {
 		try (final Surreal surreal = openMemoryDatabase()) {
-			assertThrows(SurrealException.class, () -> surreal.queryBind("RETURN $profile",
+			assertThrows(SurrealException.class, () -> surreal.query("RETURN $profile",
 					Collections.singletonMap("profile", new DuplicateSurrealNameProfile())));
 		}
 	}
@@ -277,7 +299,7 @@ public class SurrealNameTests {
 	void rejectsDuplicateSurrealNamesDuringDeserialization() {
 		try (final Surreal surreal = openMemoryDatabase()) {
 			final Value value = surreal
-					.queryBind("RETURN $profile",
+					.query("RETURN $profile",
 							Collections.singletonMap("profile", Collections.singletonMap("duplicated_name", "value")))
 					.take(0);
 
@@ -288,7 +310,7 @@ public class SurrealNameTests {
 	@Test
 	void rejectsBlankSurrealNameDuringSerialization() {
 		try (final Surreal surreal = openMemoryDatabase()) {
-			assertThrows(SurrealException.class, () -> surreal.queryBind("RETURN $profile",
+			assertThrows(SurrealException.class, () -> surreal.query("RETURN $profile",
 					Collections.singletonMap("profile", new BlankSurrealNameProfile())));
 		}
 	}
@@ -296,7 +318,7 @@ public class SurrealNameTests {
 	@Test
 	void rejectsBlankSurrealNameDuringDeserialization() {
 		try (final Surreal surreal = openMemoryDatabase()) {
-			final Value value = surreal.queryBind("RETURN $profile",
+			final Value value = surreal.query("RETURN $profile",
 					Collections.singletonMap("profile", Collections.singletonMap("firstName", "Ada"))).take(0);
 
 			assertThrows(SurrealException.class, () -> value.get(BlankSurrealNameProfile.class));

--- a/src/test/java/com/surrealdb/SurrealNameTests.java
+++ b/src/test/java/com/surrealdb/SurrealNameTests.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
@@ -112,6 +113,21 @@ public class SurrealNameTests {
 		}
 	}
 
+	public static class HiddenBaseProfile {
+		private String id;
+
+		public HiddenBaseProfile() {
+		}
+	}
+
+	public static final class HiddenChildProfile extends HiddenBaseProfile {
+		@SurrealName("child_id")
+		private String id;
+
+		public HiddenChildProfile() {
+		}
+	}
+
 	@Test
 	void serializesAnnotatedFieldsUsingSurrealNames() {
 		try (final Surreal surreal = openMemoryDatabase()) {
@@ -160,6 +176,21 @@ public class SurrealNameTests {
 			assertAnnotatedProfile(value.get(AnnotatedProfile.class), "Grace", CREATED_AT, 11, true,
 					new BigDecimal("999.50"), Arrays.asList("snake", "case"), Optional.of("read from explicit name"),
 					"g");
+		}
+	}
+
+	@Test
+	void annotatedHiddenFieldKeepsSuperclassFieldOutOfRawNameLookup() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Map<String, java.lang.Object> values = new LinkedHashMap<>();
+			values.put("id", "raw id must not populate hidden superclass field");
+			values.put("child_id", "child");
+			final Value value = surreal.queryBind("RETURN $profile", Collections.singletonMap("profile", values))
+					.take(0);
+
+			final HiddenChildProfile profile = value.get(HiddenChildProfile.class);
+			assertEquals("child", profile.id);
+			assertNull(((HiddenBaseProfile) profile).id);
 		}
 	}
 


### PR DESCRIPTION
Add `@SurrealName` as a dependency-free way to map Java fields and record components to explicit SurrealDB object keys during conversion.

This lets users keep idiomatic Java camelCase names while storing snake_case or otherwise custom field names in SurrealDB:

```java
public final class User {
  @SurrealName("created_at")
  private ZonedDateTime createdAt;
}
```

The annotation is honored in both directions:

- Java object -> SurrealDB object
- SurrealDB object -> Java object

Unannotated fields keep the existing raw Java field-name behavior.

**Implementation Details**
Introduces `SurrealFieldNames`, an internal resolver for converter field metadata. The resolver centralizes:

- `@SurrealName` lookup
- raw field-name fallback
- duplicate resolved-name rejection
- blank annotation value rejection
- static/transient field exclusion
- inherited-field shadowing behavior

`ValueBuilder` now uses resolved field names during object serialization.

`ValueClassConverter` now builds deserialization lookups by resolved SurrealDB name instead of raw Java field name. Java field hiding is preserved: if a subclass field hides a superclass field, the superclass field is kept out of the lookup even when the subclass field is annotated to a different SurrealDB key.

Java record support is included by resolving annotations from record component backing fields while preserving the existing Java 8-compatible reflective record handling.

The write path keeps a raw-name fast path: classes with no declared `@SurrealName` fields continue using `field.getName()` directly and skip duplicate-name validation.

**Validation**
Adds POJO and record coverage for:

- annotated serialization
- annotated deserialization
- create/select round trips
- raw-name backward compatibility
- explicit-name precedence over raw keys
- unknown database key handling
- static/transient exclusion
- duplicate `@SurrealName` rejection
- blank `@SurrealName` rejection
- hidden superclass field regression
- record component mapping

**Verification**
Passed:

```text
./gradlew test recordTest spotlessCheck
```

(`recordTest` runs the record suites on JDK 16+; it is not part of the plain `test` task — see #175.)

Closes #171

**Behavior note**

Deserialization no longer assigns database keys to `static` or `transient` fields. Previously the read path matched any declared field by name, so a database key matching a `transient` (or even `static`) field would be reflectively set. Such fields are now excluded from the read lookup, mirroring the write path. Covered by `keepsStaticAndTransientFieldsUntouchedDuringDeserialization`.

