### PR TITLE
Bump SurrealDB to 3.1.4, refresh aws-lc, run CI against server v3.1.3

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -310,7 +310,7 @@ jobs:
       - name: Start SurrealDB
         uses: surrealdb/setup-surreal@7c103070ba4f544240cd287432ba70d6f50163a5 # v2
         with:
-          surrealdb_version: v3.0.5
+          surrealdb_version: v3.1.3
           surrealdb_port: 8000
           surrealdb_auth: false
           surrealdb_strict: false
@@ -355,7 +355,7 @@ jobs:
         if: runner.os != 'Windows'
         uses: surrealdb/setup-surreal@7c103070ba4f544240cd287432ba70d6f50163a5 # v2
         with:
-          surrealdb_version: v3.0.5
+          surrealdb_version: v3.1.3
           surrealdb_port: 8000
           surrealdb_auth: false
           surrealdb_strict: false

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Start SurrealDB
         uses: surrealdb/setup-surreal@7c103070ba4f544240cd287432ba70d6f50163a5 # v2
         with:
-          surrealdb_version: v3.0.5
+          surrealdb_version: v3.1.3
           surrealdb_port: 8000
           surrealdb_auth: false
           surrealdb_strict: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Start SurrealDB
         uses: surrealdb/setup-surreal@7c103070ba4f544240cd287432ba70d6f50163a5 # v2
         with:
-          surrealdb_version: v3.0.5
+          surrealdb_version: v3.1.3
           surrealdb_port: 8000
           surrealdb_auth: false
           surrealdb_strict: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Refresh `aws-lc-rs`/`aws-lc-sys` in the lockfile, clearing two high security advisories (GHSA-9f94-5g5w-gf6r, GHSA-394x-vwmw-crm3) [#177](https://github.com/surrealdb/surrealdb.java/pull/177).
 - Run CI against SurrealDB server v3.1.3, the first public 3.1.x server release [#177](https://github.com/surrealdb/surrealdb.java/pull/177).
 - Run the Java-record test suite in CI [#178](https://github.com/surrealdb/surrealdb.java/pull/178).
+- Serialize inherited POJO fields: writes now walk the user-defined class hierarchy with the same hiding, naming, and validation semantics as reads [#179](https://github.com/surrealdb/surrealdb.java/pull/179).
 
 ## [2.1.0] - 2026-06-04
 - Upgrade the native layer to the `jni` crate 0.22.4; the Java/JNI ABI, public API, and JDK 8 minimum are unchanged [#166](https://github.com/surrealdb/surrealdb.java/pull/166).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+- Support more Java datetime types in value conversion: `Instant`, `OffsetDateTime`, `LocalDateTime` (interpreted as UTC), `java.util.Date`, and the `java.sql` date types, in query bindings, `Array.of()`/`Id.from()`, and POJO/record round trips [#172](https://github.com/surrealdb/surrealdb.java/pull/172).
+- Add `@SurrealName` to map Java fields and record components to explicit SurrealDB object keys, honored in both serialization and deserialization [#173](https://github.com/surrealdb/surrealdb.java/pull/173).
+- Upgrade to SurrealDB SDK 3.1.4 [#177](https://github.com/surrealdb/surrealdb.java/pull/177).
+- Refresh `aws-lc-rs`/`aws-lc-sys` in the lockfile, clearing two high security advisories (GHSA-9f94-5g5w-gf6r, GHSA-394x-vwmw-crm3) [#177](https://github.com/surrealdb/surrealdb.java/pull/177).
+- Run CI against SurrealDB server v3.1.3, the first public 3.1.x server release [#177](https://github.com/surrealdb/surrealdb.java/pull/177).
 
 ## [2.1.0] - 2026-06-04
 - Upgrade the native layer to the `jni` crate 0.22.4; the Java/JNI ABI, public API, and JDK 8 minimum are unchanged [#166](https://github.com/surrealdb/surrealdb.java/pull/166).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Upgrade to SurrealDB SDK 3.1.4 [#177](https://github.com/surrealdb/surrealdb.java/pull/177).
 - Refresh `aws-lc-rs`/`aws-lc-sys` in the lockfile, clearing two high security advisories (GHSA-9f94-5g5w-gf6r, GHSA-394x-vwmw-crm3) [#177](https://github.com/surrealdb/surrealdb.java/pull/177).
 - Run CI against SurrealDB server v3.1.3, the first public 3.1.x server release [#177](https://github.com/surrealdb/surrealdb.java/pull/177).
+- Run the Java-record test suite in CI [#178](https://github.com/surrealdb/surrealdb.java/pull/178).
 
 ## [2.1.0] - 2026-06-04
 - Upgrade the native layer to the `jni` crate 0.22.4; the Java/JNI ABI, public API, and JDK 8 minimum are unchanged [#166](https://github.com/surrealdb/surrealdb.java/pull/166).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3957,9 +3957,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddeca7bd0efc07675ddc3ec7b8e5eba2e8268b4d6c8bbcd31fcdfeab6f0484a"
+checksum = "6d9deae5add485b4b5492f9f1a05500e24e4ad272896547835e0c9696b44d05b"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3995,9 +3995,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-collections"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430d104b7ecdcfec487cfb6eb227475ec648f03c2bf991e26641bc309607b7b8"
+checksum = "d5e09c94ab7abc679f18b47367d70db7ee902553f4fec4fb0a9c92286938abc3"
 dependencies = [
  "revision",
  "storekey",
@@ -4005,9 +4005,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e4926bc2f0cd6d1eb6a95da2024432510cbf37571133c22c62ddce3d98e22a"
+checksum = "f3097d6247661f5c5a319fa1f4683d5beba2956c6b86615ad69b55f988ab135b"
 dependencies = [
  "addr",
  "affinitypool",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-java"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "async-channel",
  "cargo-lock",
@@ -4147,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-strand"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95440b332afe817529f0c6dc7440eb512cd43dd71325af0aeade47deaa843d5e"
+checksum = "7ef42225a4fe1f281b52520ee6042ce1545ffbeae2431034635662538efad740"
 dependencies = [
  "revision",
  "serde",
@@ -4158,9 +4158,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcc4329473a0d81be33a39b38e576e252d037d38ac4dd057283f1035826d0ae"
+checksum = "44b03150b36ee46f24cc2dbb22659426c42661ea484769d6345ebb3542e88fa7"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4189,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de5361377f98a936bb6416daa769811bc66bb94e5804abc6c26ac18c7f01870"
+checksum = "023873912963cb7cd58b5d158f68081af629dba13236152f96a4cff8b3dd3fc6"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,9 +223,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-java"
-version = "3.1.3"
+version = "3.1.4"
 authors = ["Emmanuel Keller <emmanuel.keller@surrealdb.com>"]
 edition = "2021"
 
@@ -19,16 +19,16 @@ opt-level = 3
 # Driver-specific dependencies (jni, once_cell, cargo-lock) are independent.
 [dependencies]
 jni = "0.22.4"
-surrealdb = { version = "3.1.3", default-features = false, features = ["rustls", "protocol-http", "protocol-ws"] }
+surrealdb = { version = "3.1.4", default-features = false, features = ["rustls", "protocol-http", "protocol-ws"] }
 serde = "1.0.228"
 serde_json = "1.0.149"
 rust_decimal = "1.40.0"
 tokio = "1.49.0"
 parking_lot = "0.12.5"
 once_cell = "1.21.4"
-chrono = "0.4.43"
+chrono = "0.4.44"
 dashmap = "6.1.0"
-futures = "0.3.31"
+futures = "0.3.32"
 async-channel = "2.5.0"
 
 [build-dependencies]


### PR DESCRIPTION
Dependency and CI refresh ahead of the 2.1.1 release.

**SurrealDB SDK 3.1.3 → 3.1.4**

- `Cargo.toml` dependency and `[package].version` mirror bumped together (repo convention), lockfile updated with `cargo update -p surrealdb --precise 3.1.4` for a minimal diff.
- `chrono` (0.4.44) and `futures` (0.3.32) floors aligned with the surrealdb 3.1.4 workspace requirements.
- `cargo check` is clean — no JNI binding changes required.

**aws-lc lockfile refresh (separate commit — drop it if we'd rather keep deferring upstream)**

- Lockfile-only: `aws-lc-rs 1.16.1 → 1.17.0`, `aws-lc-sys 0.38.0 → 0.41.0`, within the existing semver requirements; nothing is pinned or `[patch]`-overridden in `Cargo.toml`.
- Clears the two open high Dependabot alerts (GHSA-9f94-5g5w-gf6r, GHSA-394x-vwmw-crm3; patched in aws-lc-sys 0.39.0) that were deliberately deferred when scoping 2.1.0.
- The cross-compile matrix on this PR validates the new aws-lc C build on all targets.

**CI server v3.0.5 → v3.1.3**

- Public 3.1.x server releases became available on 2026-06-05; this aligns the remote-protocol test server (`setup-surreal` in `test.yml`, `reports.yml`, `cross.yml`) with the embedded 3.1.x engine.

**Changelog**

- Adds the missing `[Unreleased]` entries for #172 and #173, plus entries for the changes above.

**Note on the duplicate `jni` lockfile entry**

`Cargo.lock` intentionally keeps `jni 0.21.1` alongside our `jni 0.22.4`: the old version is required by `rustls-platform-verifier` (an Android-target dependency of reqwest). It is not an orphan and should not be manually removed; it will converge once that transitive advances upstream.

**Verification**

```text
cargo check                              # clean against 3.1.4
./gradlew test                           # 313 tests, 1 env-only failure (connectWebsocket, needs local server)
./gradlew recordTest spotlessCheck       # pass
```
