### PR TITLE
Run the record test suite in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,4 +80,4 @@ jobs:
       - name: Test
         run: |
           chmod +x gradlew
-          ./gradlew -i test jacocoTestReport
+          ./gradlew -i test recordTest jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -242,6 +242,15 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
     // Disable the auto-generated tasks for the recordTest source set on older JDKs.
     tasks.named('compileRecordTestJava') { enabled = false }
     tasks.matching { it.name == 'processRecordTestResources' }.configureEach { enabled = false }
+
+    // Disabled placeholder so `gradlew recordTest` is invocable on every JDK
+    // (the CI matrix runs it on all legs); it reports SKIPPED instead of
+    // failing with "task not found".
+    tasks.register('recordTest') {
+        description = 'Runs the Java-record tests (requires JDK 16+; skipped on this JDK).'
+        group = 'verification'
+        enabled = false
+    }
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,12 @@ test {
     // afterTest { d, r -> logger.lifecycle("[{}] END   {} > {} => {}", System.currentTimeMillis(), d.className, d.name, r.resultType) }
     testLogging {
         events "passed", "failed", "skipped"
+        // Also emit the events at INFO level, otherwise `gradlew -i` (as used
+        // in CI) hides them: Gradle switches to the per-level event set, which
+        // is empty by default.
+        info {
+            events "passed", "failed", "skipped"
+        }
         showStackTraces = true
         exceptionFormat = "full"
     }
@@ -232,6 +238,9 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
         maxParallelForks = 1
         testLogging {
             events "passed", "failed", "skipped"
+            info {
+                events "passed", "failed", "skipped"
+            }
             showStackTraces = true
             exceptionFormat = "full"
         }


### PR DESCRIPTION
The `recordTest` source set (`RecordCrudTests`, `RecordRoundTripTests`, `SurrealNameRecordTests`) was only wired into `check`, while CI runs `gradlew test` — so the record tests never executed in CI.

**Changes**

- The test matrix now runs `./gradlew -i test recordTest jacocoTestReport` on every leg.
- `build.gradle` registers a **disabled placeholder** `recordTest` task on JDKs below 16, so the uniform invocation succeeds everywhere: on the 8/11 legs it reports `> Task :recordTest SKIPPED` instead of failing with *task not found*; on 17/21/25 the real record suites run.

**Verification**

- JDK 23 locally: `./gradlew recordTest` runs all record suites, green.
- Old-JDK path simulated by raising the version gate above the local JDK: `./gradlew test recordTest` → regular tests run, `recordTest` reports SKIPPED, build succeeds.
- This PR's own 8/11 matrix legs are the real-world proof of the placeholder path.

Closes #175