### PR TITLE
Serialize inherited POJO fields

### DIFF
--- a/src/main/java/com/surrealdb/SurrealFieldNames.java
+++ b/src/main/java/com/surrealdb/SurrealFieldNames.java
@@ -56,13 +56,15 @@ final class SurrealFieldNames {
 		Class<?> c = clazz;
 		while (c != null && !isJdkType(c)) {
 			for (final Field field : c.getDeclaredFields()) {
-				if (!isSerializableField(field)) {
+				// Java field hiding is based on the declared Java name, not the
+				// resolved SurrealDB name, and applies to every declared field
+				// (JLS 8.3) — including static and transient ones. Record the
+				// name before the serializability check so a non-serializable
+				// hider still keeps its hidden superclass field out.
+				if (!seenJavaNames.add(field.getName())) {
 					continue;
 				}
-				// Java field hiding is based on the declared Java name, not the
-				// resolved SurrealDB name. Keep hidden superclass fields out even
-				// when the subclass field is annotated to a different key.
-				if (!seenJavaNames.add(field.getName())) {
+				if (!isSerializableField(field)) {
 					continue;
 				}
 				final String name = nameFor(field);

--- a/src/main/java/com/surrealdb/SurrealFieldNames.java
+++ b/src/main/java/com/surrealdb/SurrealFieldNames.java
@@ -2,8 +2,8 @@ package com.surrealdb;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,21 +38,23 @@ final class SurrealFieldNames {
 		return false;
 	}
 
-	static void ensureUniqueDeclaredNames(final Class<?> clazz) {
-		final Map<String, Field> fields = new HashMap<>();
-		for (final Field field : clazz.getDeclaredFields()) {
-			if (!isSerializableField(field)) {
-				continue;
-			}
-			putUnique(fields, nameFor(field), field);
-		}
+	static boolean hasUserSuperclass(final Class<?> clazz) {
+		final Class<?> superclass = clazz.getSuperclass();
+		return superclass != null && !isJdkType(superclass);
 	}
 
+	/**
+	 * Maps resolved SurrealDB keys to their fields, walking the user-defined part
+	 * of the class hierarchy (subclass first, in declaration order). The walk stops
+	 * at the first JDK class so JDK internals (e.g. {@code java.lang.Enum.name},
+	 * {@code Throwable.detailMessage}) are never serialized or reflectively
+	 * assigned.
+	 */
 	static Map<String, Field> inheritedFieldsBySurrealName(final Class<?> clazz) {
-		final Map<String, Field> fields = new HashMap<>();
+		final Map<String, Field> fields = new LinkedHashMap<>();
 		final Set<String> seenJavaNames = new HashSet<>();
 		Class<?> c = clazz;
-		while (c != null && c != java.lang.Object.class) {
+		while (c != null && !isJdkType(c)) {
 			for (final Field field : c.getDeclaredFields()) {
 				if (!isSerializableField(field)) {
 					continue;
@@ -74,11 +76,10 @@ final class SurrealFieldNames {
 		return fields;
 	}
 
-	private static void putUnique(final Map<String, Field> fields, final String name, final Field field) {
-		final Field previous = fields.put(name, field);
-		if (previous != null) {
-			throw duplicateName(name, previous, field);
-		}
+	private static boolean isJdkType(final Class<?> clazz) {
+		final String name = clazz.getName();
+		return name.startsWith("java.") || name.startsWith("javax.") || name.startsWith("jdk.")
+				|| name.startsWith("sun.") || name.startsWith("com.sun.");
 	}
 
 	private static SurrealException duplicateName(final String name, final Field first, final Field second) {

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -114,25 +114,43 @@ class ValueBuilder {
 		if (object instanceof Object) {
 			return ValueMut.createObject((Object) object);
 		}
-		final Field[] fields = object.getClass().getDeclaredFields();
-		if (fields.length > 0) {
-			final boolean hasSurrealName = SurrealFieldNames.hasDeclaredSurrealName(fields);
-			if (hasSurrealName) {
-				SurrealFieldNames.ensureUniqueDeclaredNames(object.getClass());
-			}
-			final List<EntryMut> entries = new ArrayList<>(fields.length);
-			for (final Field field : fields) {
-				if (!SurrealFieldNames.isSerializableField(field)) {
-					continue;
+		final Class<?> clazz = object.getClass();
+		final Field[] declaredFields = clazz.getDeclaredFields();
+		if (!SurrealFieldNames.hasUserSuperclass(clazz) && !SurrealFieldNames.hasDeclaredSurrealName(declaredFields)) {
+			// Fast path: a single user-defined class with raw Java names. Java
+			// forbids duplicate field names within one class, so there is
+			// nothing to validate.
+			if (declaredFields.length > 0) {
+				final List<EntryMut> entries = new ArrayList<>(declaredFields.length);
+				for (final Field field : declaredFields) {
+					if (!SurrealFieldNames.isSerializableField(field)) {
+						continue;
+					}
+					field.setAccessible(true);
+					final java.lang.Object value = field.get(object);
+					if (value != null) {
+						entries.add(EntryMut.newEntry(field.getName(), convert(value)));
+					}
 				}
-				field.setAccessible(true);
-				final String name = hasSurrealName ? SurrealFieldNames.nameFor(field) : field.getName();
-				final java.lang.Object value = field.get(object);
-				if (value != null) {
-					entries.add(EntryMut.newEntry(name, convert(value)));
-				}
+				return ValueMut.createObject(entries);
 			}
-			return ValueMut.createObject(entries);
+		} else {
+			// Mirror the read path (ValueClassConverter): walk the user-defined
+			// hierarchy with the same hiding, naming, and duplicate-rejection
+			// semantics so objects round-trip symmetrically.
+			final Map<String, Field> fields = SurrealFieldNames.inheritedFieldsBySurrealName(clazz);
+			if (!fields.isEmpty() || declaredFields.length > 0) {
+				final List<EntryMut> entries = new ArrayList<>(fields.size());
+				for (final Map.Entry<String, Field> fieldEntry : fields.entrySet()) {
+					final Field field = fieldEntry.getValue();
+					field.setAccessible(true);
+					final java.lang.Object value = field.get(object);
+					if (value != null) {
+						entries.add(EntryMut.newEntry(fieldEntry.getKey(), convert(value)));
+					}
+				}
+				return ValueMut.createObject(entries);
+			}
 		}
 		throw new SurrealException("No field found: " + object.getClass().getCanonicalName());
 	}

--- a/src/test/java/com/surrealdb/InheritedFieldsTests.java
+++ b/src/test/java/com/surrealdb/InheritedFieldsTests.java
@@ -3,10 +3,13 @@ package com.surrealdb;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 
@@ -84,6 +87,36 @@ public class InheritedFieldsTests {
 		public String code;
 
 		public CodedException() {
+		}
+	}
+
+	public static class CredentialBaseProfile {
+		public String password;
+
+		public CredentialBaseProfile() {
+		}
+	}
+
+	public static final class CredentialChildProfile extends CredentialBaseProfile {
+		public String name;
+		public transient String password;
+
+		public CredentialChildProfile() {
+		}
+	}
+
+	public static class CountedBaseProfile {
+		public String counter;
+
+		public CountedBaseProfile() {
+		}
+	}
+
+	public static final class CountedChildProfile extends CountedBaseProfile {
+		public String name;
+		public static String counter;
+
+		public CountedChildProfile() {
 		}
 	}
 
@@ -171,6 +204,46 @@ public class InheritedFieldsTests {
 			// (detailMessage, stackTrace, ...) stay out.
 			assertEquals(Collections.singletonList("error_code"), keys(value.getObject()));
 			assertFalse(keys(value.getObject()).contains("detailMessage"));
+		}
+	}
+
+	@Test
+	void transientSubclassFieldHidesSuperclassFieldOnWrite() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final CredentialChildProfile profile = new CredentialChildProfile();
+			profile.name = "Ada";
+			((CredentialBaseProfile) profile).password = "secret";
+
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", profile)).take(0);
+
+			assertEquals(Collections.singletonList("name"), keys(value.getObject()));
+		}
+	}
+
+	@Test
+	void transientSubclassFieldHidesSuperclassFieldOnRead() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final Map<String, java.lang.Object> values = new LinkedHashMap<>();
+			values.put("name", "Ada");
+			values.put("password", "from database");
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", values)).take(0);
+
+			final CredentialChildProfile read = value.get(CredentialChildProfile.class);
+			assertEquals("Ada", read.name);
+			assertNull(((CredentialBaseProfile) read).password);
+		}
+	}
+
+	@Test
+	void staticSubclassFieldHidesSuperclassFieldOnWrite() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final CountedChildProfile profile = new CountedChildProfile();
+			profile.name = "Ada";
+			((CountedBaseProfile) profile).counter = "base value";
+
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", profile)).take(0);
+
+			assertEquals(Collections.singletonList("name"), keys(value.getObject()));
 		}
 	}
 

--- a/src/test/java/com/surrealdb/InheritedFieldsTests.java
+++ b/src/test/java/com/surrealdb/InheritedFieldsTests.java
@@ -1,0 +1,191 @@
+package com.surrealdb;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Serialization of inherited POJO fields (issue #174): the write path walks the
+ * user-defined class hierarchy with the same semantics as the read path.
+ */
+public class InheritedFieldsTests {
+
+	public static class BaseProfile {
+		public String slug;
+		public static String cached = "must not serialize";
+		public transient String temporary = "must not serialize";
+
+		public BaseProfile() {
+		}
+	}
+
+	public static final class ChildProfile extends BaseProfile {
+		public String name;
+
+		public ChildProfile() {
+		}
+	}
+
+	public static class AnnotatedBaseProfile {
+		@SurrealName("created_at")
+		public String createdAt;
+
+		public AnnotatedBaseProfile() {
+		}
+	}
+
+	public static final class AnnotatedChildProfile extends AnnotatedBaseProfile {
+		public String name;
+
+		public AnnotatedChildProfile() {
+		}
+	}
+
+	public static class HiddenBaseProfile {
+		public String id;
+
+		public HiddenBaseProfile() {
+		}
+	}
+
+	public static final class HiddenChildProfile extends HiddenBaseProfile {
+		@SurrealName("child_id")
+		public String id;
+
+		public HiddenChildProfile() {
+		}
+	}
+
+	public static class DuplicateBaseProfile {
+		public String code;
+
+		public DuplicateBaseProfile() {
+		}
+	}
+
+	public static final class DuplicateChildProfile extends DuplicateBaseProfile {
+		@SurrealName("code")
+		public String childCode;
+
+		public DuplicateChildProfile() {
+		}
+	}
+
+	public static final class CodedException extends RuntimeException {
+		// Annotated so serialization takes the hierarchy walk rather than the
+		// single-class fast path; the walk must stop at RuntimeException.
+		@SurrealName("error_code")
+		public String code;
+
+		public CodedException() {
+		}
+	}
+
+	@Test
+	void writeIncludesInheritedFields() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final ChildProfile profile = new ChildProfile();
+			profile.slug = "abc";
+			profile.name = "Tobie";
+
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", profile)).take(0);
+
+			assertEquals(Arrays.asList("name", "slug"), keys(value.getObject()));
+			final ChildProfile read = value.get(ChildProfile.class);
+			assertEquals("abc", read.slug);
+			assertEquals("Tobie", read.name);
+		}
+	}
+
+	@Test
+	void roundTripsInheritedFieldsThroughCreateAndSelect() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final ChildProfile profile = new ChildProfile();
+			profile.slug = "abc";
+			profile.name = "Tobie";
+
+			final ChildProfile created = surreal.create(ChildProfile.class, "child_profile", profile).get(0);
+
+			assertEquals("abc", created.slug);
+			assertEquals("Tobie", created.name);
+		}
+	}
+
+	@Test
+	void honorsSurrealNameOnInheritedFields() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final AnnotatedChildProfile profile = new AnnotatedChildProfile();
+			profile.createdAt = "2026-06-10";
+			profile.name = "Ada";
+
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", profile)).take(0);
+
+			assertEquals(Arrays.asList("created_at", "name"), keys(value.getObject()));
+			final AnnotatedChildProfile read = value.get(AnnotatedChildProfile.class);
+			assertEquals("2026-06-10", read.createdAt);
+			assertEquals("Ada", read.name);
+		}
+	}
+
+	@Test
+	void doesNotWriteHiddenSuperclassFields() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final HiddenChildProfile profile = new HiddenChildProfile();
+			profile.id = "child";
+			((HiddenBaseProfile) profile).id = "hidden base value";
+
+			final Value value = surreal.query("RETURN $profile", Collections.singletonMap("profile", profile)).take(0);
+
+			assertEquals(Collections.singletonList("child_id"), keys(value.getObject()));
+			assertEquals("child", value.getObject().get("child_id").getString());
+		}
+	}
+
+	@Test
+	void rejectsDuplicateResolvedNamesAcrossHierarchyDuringSerialization() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final DuplicateChildProfile profile = new DuplicateChildProfile();
+			profile.code = "base";
+			profile.childCode = "child";
+
+			assertThrows(SurrealException.class,
+					() -> surreal.query("RETURN $profile", Collections.singletonMap("profile", profile)));
+		}
+	}
+
+	@Test
+	void stopsHierarchyWalkAtJdkClasses() {
+		try (final Surreal surreal = openMemoryDatabase()) {
+			final CodedException coded = new CodedException();
+			coded.code = "E42";
+
+			final Value value = surreal.query("RETURN $coded", Collections.singletonMap("coded", coded)).take(0);
+
+			// Only the user-declared field is serialized; Throwable internals
+			// (detailMessage, stackTrace, ...) stay out.
+			assertEquals(Collections.singletonList("error_code"), keys(value.getObject()));
+			assertFalse(keys(value.getObject()).contains("detailMessage"));
+		}
+	}
+
+	private static Surreal openMemoryDatabase() {
+		final Surreal surreal = new Surreal();
+		surreal.connect("memory").useNs("inherited_fields_tests").useDb("inherited_fields_tests");
+		return surreal;
+	}
+
+	private static List<String> keys(final Object object) {
+		final List<String> keys = new ArrayList<>();
+		for (final Entry entry : object) {
+			keys.add(entry.getKey());
+		}
+		Collections.sort(keys);
+		return keys;
+	}
+}


### PR DESCRIPTION
Fixes the write/read asymmetry from #174: the serialization path only iterated `getClass().getDeclaredFields()`, so fields declared on superclasses were silently dropped on write while the read path walked the full hierarchy.

**Changes**

- `ValueBuilder` now serializes through `SurrealFieldNames.inheritedFieldsBySurrealName` — the same resolver the read path (`ValueClassConverter`) uses — so writes get identical semantics: hierarchy walk, Java field hiding by declared name, `@SurrealName` resolution, static/transient exclusion, and duplicate resolved-name rejection.
- The shared hierarchy walk now **stops at the first JDK class** (`java.*`, `javax.*`, `jdk.*`, `sun.*`). Without this, walking would pull JDK internals into serialization (e.g. `java.lang.Enum.name`, `Throwable.detailMessage`) and fail with `InaccessibleObjectException` on JDK 17+ when calling `setAccessible` on `java.base` fields. This also hardens the read path, which previously walked unbounded.
- The resolver returns a `LinkedHashMap`, making write order deterministic (subclass first, declaration order).
- The single-class fast path from #173 is preserved: unannotated classes with no user-defined superclass serialize their raw declared fields directly, with no validation overhead.

**Behavior note**

Inherited fields now persist — previously `create(Child.class, ...)` on a subclass silently dropped every superclass field. Code that (knowingly or not) relied on inherited fields being excluded from writes will see them stored from this release on.

**Validation** (`InheritedFieldsTests`)

- inherited fields are written and round-trip via `create`/`select`
- `@SurrealName` on superclass fields is honored on write
- hidden superclass fields stay out of the serialized object
- non-serializable hiders work per JLS 8.3: a `transient` or `static` subclass field keeps its hidden superclass field out of both writes and reads (Codex review finding)
- duplicate resolved names across the hierarchy are rejected on write
- the hierarchy walk stops at JDK classes (custom `RuntimeException` subclass serializes only its own field)
- static/transient superclass members remain excluded

**Verification**

```text
./gradlew test recordTest spotlessCheck   # 319 tests; 1 env-only failure (connectWebsocket, needs local server)
```

Closes #174

