### PR TITLE
Cache per-class field metadata in the value converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Cache per-class field metadata in the value converters [#180](https://github.com/surrealdb/surrealdb.java/pull/180).
 - Support more Java datetime types in value conversion: `Instant`, `OffsetDateTime`, `LocalDateTime` (interpreted as UTC), `java.util.Date`, and the `java.sql` date types, in query bindings, `Array.of()`/`Id.from()`, and POJO/record round trips [#172](https://github.com/surrealdb/surrealdb.java/pull/172).
 - Add `@SurrealName` to map Java fields and record components to explicit SurrealDB object keys, honored in both serialization and deserialization [#173](https://github.com/surrealdb/surrealdb.java/pull/173).
 - Upgrade to SurrealDB SDK 3.1.4 [#177](https://github.com/surrealdb/surrealdb.java/pull/177).

--- a/src/main/java/com/surrealdb/SurrealFieldNames.java
+++ b/src/main/java/com/surrealdb/SurrealFieldNames.java
@@ -2,6 +2,7 @@ package com.surrealdb;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -9,12 +10,20 @@ import java.util.Set;
 
 final class SurrealFieldNames {
 
-	private SurrealFieldNames() {
-	}
+	// Field metadata is immutable at runtime (declared fields and annotations
+	// cannot change), so the resolved map is computed once per class. ClassValue
+	// ties the cache entry to the class lifetime, so classes remain unloadable
+	// (no static Map<Class, ...> leak). If computeValue throws (blank or
+	// duplicate @SurrealName), nothing is installed and the same exception is
+	// thrown again on the next attempt.
+	private static final ClassValue<Map<String, Field>> FIELDS_BY_SURREAL_NAME = new ClassValue<Map<String, Field>>() {
+		@Override
+		protected Map<String, Field> computeValue(final Class<?> clazz) {
+			return Collections.unmodifiableMap(buildFieldsBySurrealName(clazz));
+		}
+	};
 
-	static boolean isSerializableField(final Field field) {
-		final int mods = field.getModifiers();
-		return !Modifier.isStatic(mods) && !Modifier.isTransient(mods);
+	private SurrealFieldNames() {
 	}
 
 	static String nameFor(final Field field) {
@@ -29,28 +38,21 @@ final class SurrealFieldNames {
 		return value;
 	}
 
-	static boolean hasDeclaredSurrealName(final Field[] fields) {
-		for (final Field field : fields) {
-			if (isSerializableField(field) && field.getAnnotation(SurrealName.class) != null) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	static boolean hasUserSuperclass(final Class<?> clazz) {
-		final Class<?> superclass = clazz.getSuperclass();
-		return superclass != null && !isJdkType(superclass);
-	}
-
 	/**
 	 * Maps resolved SurrealDB keys to their fields, walking the user-defined part
 	 * of the class hierarchy (subclass first, in declaration order). The walk stops
 	 * at the first JDK class so JDK internals (e.g. {@code java.lang.Enum.name},
 	 * {@code Throwable.detailMessage}) are never serialized or reflectively
 	 * assigned.
+	 * <p>
+	 * The returned map is cached per class and unmodifiable; its fields are already
+	 * accessible.
 	 */
 	static Map<String, Field> inheritedFieldsBySurrealName(final Class<?> clazz) {
+		return FIELDS_BY_SURREAL_NAME.get(clazz);
+	}
+
+	private static Map<String, Field> buildFieldsBySurrealName(final Class<?> clazz) {
 		final Map<String, Field> fields = new LinkedHashMap<>();
 		final Set<String> seenJavaNames = new HashSet<>();
 		Class<?> c = clazz;
@@ -71,11 +73,17 @@ final class SurrealFieldNames {
 				if (fields.containsKey(name)) {
 					throw duplicateName(name, fields.get(name), field);
 				}
+				field.setAccessible(true);
 				fields.put(name, field);
 			}
 			c = c.getSuperclass();
 		}
 		return fields;
+	}
+
+	private static boolean isSerializableField(final Field field) {
+		final int mods = field.getModifiers();
+		return !Modifier.isStatic(mods) && !Modifier.isTransient(mods);
 	}
 
 	private static boolean isJdkType(final Class<?> clazz) {

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -115,44 +115,21 @@ class ValueBuilder {
 			return ValueMut.createObject((Object) object);
 		}
 		final Class<?> clazz = object.getClass();
-		final Field[] declaredFields = clazz.getDeclaredFields();
-		if (!SurrealFieldNames.hasUserSuperclass(clazz) && !SurrealFieldNames.hasDeclaredSurrealName(declaredFields)) {
-			// Fast path: a single user-defined class with raw Java names. Java
-			// forbids duplicate field names within one class, so there is
-			// nothing to validate.
-			if (declaredFields.length > 0) {
-				final List<EntryMut> entries = new ArrayList<>(declaredFields.length);
-				for (final Field field : declaredFields) {
-					if (!SurrealFieldNames.isSerializableField(field)) {
-						continue;
-					}
-					field.setAccessible(true);
-					final java.lang.Object value = field.get(object);
-					if (value != null) {
-						entries.add(EntryMut.newEntry(field.getName(), convert(value)));
-					}
-				}
-				return ValueMut.createObject(entries);
-			}
-		} else {
-			// Mirror the read path (ValueClassConverter): walk the user-defined
-			// hierarchy with the same hiding, naming, and duplicate-rejection
-			// semantics so objects round-trip symmetrically.
-			final Map<String, Field> fields = SurrealFieldNames.inheritedFieldsBySurrealName(clazz);
-			if (!fields.isEmpty() || declaredFields.length > 0) {
-				final List<EntryMut> entries = new ArrayList<>(fields.size());
-				for (final Map.Entry<String, Field> fieldEntry : fields.entrySet()) {
-					final Field field = fieldEntry.getValue();
-					field.setAccessible(true);
-					final java.lang.Object value = field.get(object);
-					if (value != null) {
-						entries.add(EntryMut.newEntry(fieldEntry.getKey(), convert(value)));
-					}
-				}
-				return ValueMut.createObject(entries);
+		// Mirror the read path (ValueClassConverter): the cached resolver walks
+		// the user-defined hierarchy with the same hiding, naming, and
+		// duplicate-rejection semantics so objects round-trip symmetrically.
+		final Map<String, Field> fields = SurrealFieldNames.inheritedFieldsBySurrealName(clazz);
+		if (fields.isEmpty() && clazz.getDeclaredFields().length == 0) {
+			throw new SurrealException("No field found: " + clazz.getCanonicalName());
+		}
+		final List<EntryMut> entries = new ArrayList<>(fields.size());
+		for (final Map.Entry<String, Field> fieldEntry : fields.entrySet()) {
+			final java.lang.Object value = fieldEntry.getValue().get(object);
+			if (value != null) {
+				entries.add(EntryMut.newEntry(fieldEntry.getKey(), convert(value)));
 			}
 		}
-		throw new SurrealException("No field found: " + object.getClass().getCanonicalName());
+		return ValueMut.createObject(entries);
 	}
 
 	static <T> ValueMut convert(final T object) {

--- a/src/main/java/com/surrealdb/ValueClassConverter.java
+++ b/src/main/java/com/surrealdb/ValueClassConverter.java
@@ -301,7 +301,6 @@ class ValueClassConverter<T> {
 				// Safe to ignore: source has a key with no matching field.
 				continue;
 			}
-			field.setAccessible(true);
 			final java.lang.Object converted = convertValueToType(value, field.getType(), field.getGenericType());
 			if (converted == null && field.getType().isPrimitive()) {
 				// Leave primitive fields at their default value; setting null would throw.
@@ -312,25 +311,57 @@ class ValueClassConverter<T> {
 		return target;
 	}
 
+	// Record component metadata is immutable at runtime; resolve names, types,
+	// and the canonical constructor once per record class. See the matching
+	// ClassValue note in SurrealFieldNames for the failure semantics.
+	private static final ClassValue<RecordMeta> RECORD_META = new ClassValue<RecordMeta>() {
+		@Override
+		protected RecordMeta computeValue(final Class<?> clazz) {
+			try {
+				final java.lang.Object[] componentsArray = (java.lang.Object[]) GET_RECORD_COMPONENTS.invoke(clazz);
+				final int count = componentsArray.length;
+				final String[] names = new String[count];
+				final Class<?>[] types = new Class<?>[count];
+				final Type[] genericTypes = new Type[count];
+				for (int i = 0; i < count; i++) {
+					final java.lang.Object rc = componentsArray[i];
+					final String componentName = (String) RC_GET_NAME.invoke(rc);
+					names[i] = recordComponentSurrealName(clazz, componentName);
+					types[i] = (Class<?>) RC_GET_TYPE.invoke(rc);
+					genericTypes[i] = (Type) RC_GET_GENERIC_TYPE.invoke(rc);
+				}
+				ensureUniqueRecordComponentNames(clazz, names);
+				final Constructor<?> constructor = clazz.getDeclaredConstructor(types);
+				constructor.setAccessible(true);
+				return new RecordMeta(names, types, genericTypes, constructor);
+			} catch (ReflectiveOperationException e) {
+				throw new SurrealException("Failed to read record metadata for " + clazz.getName(), e);
+			}
+		}
+	};
+
+	private static final class RecordMeta {
+		final String[] names;
+		final Class<?>[] types;
+		final Type[] genericTypes;
+		final Constructor<?> constructor;
+
+		RecordMeta(String[] names, Class<?>[] types, Type[] genericTypes, Constructor<?> constructor) {
+			this.names = names;
+			this.types = types;
+			this.genericTypes = genericTypes;
+			this.constructor = constructor;
+		}
+	}
+
 	private static <T> T convertRecord(final Class<T> clazz, final Object source) throws ReflectiveOperationException {
 		if (GET_RECORD_COMPONENTS == null) {
 			// Should be unreachable: isRecord() returned true, so the JVM exposes
 			// RecordComponent.
 			throw new SurrealException("Record reflection APIs unavailable for " + clazz.getName());
 		}
-		final java.lang.Object[] componentsArray = (java.lang.Object[]) GET_RECORD_COMPONENTS.invoke(clazz);
-		final int count = componentsArray.length;
-		final String[] names = new String[count];
-		final Class<?>[] types = new Class<?>[count];
-		final Type[] genericTypes = new Type[count];
-		for (int i = 0; i < count; i++) {
-			final java.lang.Object rc = componentsArray[i];
-			final String componentName = (String) RC_GET_NAME.invoke(rc);
-			names[i] = recordComponentSurrealName(clazz, componentName);
-			types[i] = (Class<?>) RC_GET_TYPE.invoke(rc);
-			genericTypes[i] = (Type) RC_GET_GENERIC_TYPE.invoke(rc);
-		}
-		ensureUniqueRecordComponentNames(clazz, names);
+		final RecordMeta meta = RECORD_META.get(clazz);
+		final int count = meta.names.length;
 
 		// Build a lookup of incoming entries keyed by name.
 		final Map<String, Value> entries = new HashMap<>();
@@ -340,13 +371,13 @@ class ValueClassConverter<T> {
 
 		final java.lang.Object[] args = new java.lang.Object[count];
 		for (int i = 0; i < count; i++) {
-			final Value value = entries.get(names[i]);
-			final Class<?> type = types[i];
+			final Value value = entries.get(meta.names[i]);
+			final Class<?> type = meta.types[i];
 			if (value == null) {
 				args[i] = defaultForRecordComponent(type);
 				continue;
 			}
-			final java.lang.Object converted = convertValueToType(value, type, genericTypes[i]);
+			final java.lang.Object converted = convertValueToType(value, type, meta.genericTypes[i]);
 			if (converted == null) {
 				args[i] = defaultForRecordComponent(type);
 			} else {
@@ -354,9 +385,9 @@ class ValueClassConverter<T> {
 			}
 		}
 
-		final Constructor<T> ctor = clazz.getDeclaredConstructor(types);
-		ctor.setAccessible(true);
-		return ctor.newInstance(args);
+		@SuppressWarnings("unchecked")
+		final T instance = (T) meta.constructor.newInstance(args);
+		return instance;
 	}
 
 	private static String recordComponentSurrealName(final Class<?> clazz, final String componentName)

--- a/src/test/java/com/surrealdb/SurrealNameTests.java
+++ b/src/test/java/com/surrealdb/SurrealNameTests.java
@@ -292,6 +292,10 @@ public class SurrealNameTests {
 		try (final Surreal surreal = openMemoryDatabase()) {
 			assertThrows(SurrealException.class, () -> surreal.query("RETURN $profile",
 					Collections.singletonMap("profile", new DuplicateSurrealNameProfile())));
+			// The per-class metadata cache must rethrow the validation failure
+			// on every attempt, not only on the first one.
+			assertThrows(SurrealException.class, () -> surreal.query("RETURN $profile",
+					Collections.singletonMap("profile", new DuplicateSurrealNameProfile())));
 		}
 	}
 


### PR DESCRIPTION
Field and record-component metadata is immutable at runtime, so resolve it once per class instead of on every conversion (#176). Previously `inheritedFieldsBySurrealName` rebuilt the hierarchy walk, annotation lookups, and duplicate validation for **every** converted object — including each element of a result list and each nested object.

**Changes**

- `SurrealFieldNames` caches the resolved-name field map in a `ClassValue` — tied to class lifetime, so classes stay unloadable (no static `Map<Class, ...>` leak). Fields are made accessible once at build time; the cached map is unmodifiable.
- **Failure semantics preserved**: if validation throws (blank/duplicate `@SurrealName`), `ClassValue` installs nothing and the same exception is rethrown on every subsequent attempt — covered by a new regression test.
- `ValueClassConverter` caches record metadata the same way: component names (with `@SurrealName` resolution), types, generic types, uniqueness validation, and the canonical constructor (`setAccessible` once).
- `ValueBuilder` now serializes through the cached map. The raw-name fast path from #173 is superseded: it existed to skip per-call annotation scans, which the cache eliminates for all shapes — after the first conversion of a class, the resolver is a single `ClassValue` lookup.

**Verification**

```text
./gradlew test recordTest spotlessCheck   # 322 tests; 1 env-only failure (connectWebsocket, needs local server)
```

Closes #176