### PR TITLE
Bump version to 2.1.2-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [2.1.1] - 2026-06-10
 - Support more Java datetime types in value conversion: `Instant`, `OffsetDateTime`, `LocalDateTime` (interpreted as UTC), `java.util.Date`, and the `java.sql` date types, in query bindings, `Array.of()`/`Id.from()`, and POJO/record round trips [#172](https://github.com/surrealdb/surrealdb.java/pull/172).
 - Add `@SurrealName` to map Java fields and record components to explicit SurrealDB object keys, honored in both serialization and deserialization [#173](https://github.com/surrealdb/surrealdb.java/pull/173).

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ repositories {
 }
 
 ext {
-    surrealdbVersion = "2.1.1-SNAPSHOT"
+    surrealdbVersion = "2.1.2-SNAPSHOT"
 }
 
 dependencies {
@@ -127,7 +127,7 @@ Maven:
 <dependency>
     <groupId>com.surrealdb</groupId>
     <artifactId>surrealdb</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.2-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
 }
 
 group 'com.surrealdb'
-version '2.1.1'
+version '2.1.2-SNAPSHOT'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Post-release housekeeping after publishing 2.1.1, mirroring #168:

- `build.gradle`: `2.1.1` -> `2.1.2-SNAPSHOT`
- `README.md`: snapshot-section examples -> `2.1.2-SNAPSHOT` (stable examples stay on `2.1.1`)
- `CHANGELOG.md`: fresh `[Unreleased]` section restored

Snapshots resume publishing automatically on the next push to main.