### PR TITLE
Add full geometry-type support (read + write)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4111,6 +4111,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "futures",
+ "geo",
  "jni 0.22.4",
  "once_cell",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ opt-level = 3
 [dependencies]
 jni = "0.22.4"
 surrealdb = { version = "3.1.3", default-features = false, features = ["rustls", "protocol-http", "protocol-ws"] }
+# Geometry construction (write path). Must match the geo version surrealdb-types uses
+# so the geo::* types unify with surrealdb::types::Geometry's inner geo types.
+geo = { version = "0.32", default-features = false }
 serde = "1.0.228"
 serde_json = "1.0.149"
 rust_decimal = "1.40.0"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ View the SDK documentation [here](https://surrealdb.com/docs/integration/librari
 - Support of 'memory' (embedded SurrealDB).
 - Support of remote connection to SurrealDB.
 - Mutable POJOs (Java 8+) and immutable `record` classes (JDK 16+) for `create` / `select`.
+- All geometry types (Point, LineString, Polygon, their multi-variants, and GeometryCollection) for reading and writing.
 - Supported on JAVA JDK 8, 11, 17, 21, 25.
 - Supported architectures:
     - Linux (ARM) aarch64
@@ -192,6 +193,42 @@ public class Example {
 }
 ```
 
+### Geometry
+
+All GeoJSON-style geometry types are supported — `Point`, `LineString`, `Polygon`,
+`MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection` — for both
+reading and writing. Coordinates use `java.awt.geom.Point2D.Double`, where `x` is the
+longitude and `y` is the latitude.
+
+```java
+import com.surrealdb.Geometry;
+import com.surrealdb.Surreal;
+import com.surrealdb.Value;
+
+import java.awt.geom.Point2D;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+try (final Surreal driver = new Surreal()) {
+    driver.connect("memory").useNs("test").useDb("test");
+
+    // Build a geometry in Java and store it via a bound parameter
+    Geometry route = Geometry.lineString(Arrays.asList(
+            new Point2D.Double(-0.118, 51.51),
+            new Point2D.Double(-0.121, 51.50)));
+    Map<String, Object> params = new HashMap<>();
+    params.put("route", route);
+    driver.query("UPSERT path:1 SET route = $route", params);
+
+    // Read it back
+    Value value = driver.query("SELECT VALUE route FROM path:1").take(0).getArray().get(0);
+    Geometry geom = value.getGeometry();
+    System.out.println(geom.getType());        // LineString
+    System.out.println(geom.getLineString());  // [Point2D.Double[...], Point2D.Double[...]]
+}
+```
+
 ### Reports
 
 - [Javadoc](https://surrealdb.github.io/surrealdb.java/javadoc/)
@@ -216,9 +253,7 @@ cargo build
 
 ### Planned Features
 
-- All Geometry types (actually only points)
-- Ranges
-- Future
-- Live queries
+- Futures
+- Killing live queries by ID
 
 [Open an issue for feature requests](https://github.com/surrealdb/surrealdb.java/issues)

--- a/src/main/java/com/surrealdb/Geometry.java
+++ b/src/main/java/com/surrealdb/Geometry.java
@@ -6,15 +6,17 @@ import java.util.List;
 
 /**
  * A SurrealDB geometry value. Supports all GeoJSON-style types: {@code Point},
- * {@code LineString}, {@code Polygon}, {@code MultiPoint}, {@code MultiLineString},
- * {@code MultiPolygon}, and {@code GeometryCollection}.
+ * {@code LineString}, {@code Polygon}, {@code MultiPoint},
+ * {@code MultiLineString}, {@code MultiPolygon}, and
+ * {@code GeometryCollection}.
  * <p>
  * Coordinates use {@link java.awt.geom.Point2D.Double} where {@code x} is the
  * longitude and {@code y} is the latitude (GeoJSON ordering). Multi-coordinate
  * types are exposed as nested {@link List}s of points.
  * <p>
- * Instances can be read from query results (via {@link Value#getGeometry()}) and
- * constructed with the static factory methods to be sent back to the database.
+ * Instances can be read from query results (via {@link Value#getGeometry()})
+ * and constructed with the static factory methods to be sent back to the
+ * database.
  */
 public class Geometry extends Native {
 

--- a/src/main/java/com/surrealdb/Geometry.java
+++ b/src/main/java/com/surrealdb/Geometry.java
@@ -1,16 +1,54 @@
 package com.surrealdb;
 
 import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
 
+/**
+ * A SurrealDB geometry value. Supports all GeoJSON-style types: {@code Point},
+ * {@code LineString}, {@code Polygon}, {@code MultiPoint}, {@code MultiLineString},
+ * {@code MultiPolygon}, and {@code GeometryCollection}.
+ * <p>
+ * Coordinates use {@link java.awt.geom.Point2D.Double} where {@code x} is the
+ * longitude and {@code y} is the latitude (GeoJSON ordering). Multi-coordinate
+ * types are exposed as nested {@link List}s of points.
+ * <p>
+ * Instances can be read from query results (via {@link Value#getGeometry()}) and
+ * constructed with the static factory methods to be sent back to the database.
+ */
 public class Geometry extends Native {
 
 	Geometry(long ptr) {
 		super(ptr);
 	}
 
+	// ---- native: read ----
+
 	private static native boolean isPoint(long ptr);
 
 	private static native double[] getPoint(long ptr);
+
+	private static native String getType(long ptr);
+
+	private static native long getCoordinates(long ptr);
+
+	private static native long[] getCollection(long ptr);
+
+	// ---- native: write ----
+
+	private static native long newPoint(double x, double y);
+
+	private static native long newLineString(double[] coords);
+
+	private static native long newPolygon(double[][] rings);
+
+	private static native long newMultiPoint(double[] coords);
+
+	private static native long newMultiLineString(double[][] lines);
+
+	private static native long newMultiPolygon(double[][][] polygons);
+
+	private static native long newCollection(long[] geometryPtrs);
 
 	@Override
 	final native String toString(long ptr);
@@ -24,12 +62,178 @@ public class Geometry extends Native {
 	@Override
 	final native void deleteInstance(long ptr);
 
+	// ---- type discrimination ----
+
+	/**
+	 * Returns the geometry type: one of {@code "Point"}, {@code "LineString"},
+	 * {@code "Polygon"}, {@code "MultiPoint"}, {@code "MultiLineString"},
+	 * {@code "MultiPolygon"}, or {@code "GeometryCollection"}.
+	 */
+	public String getType() {
+		return getType(getPtr());
+	}
+
 	public boolean isPoint() {
 		return isPoint(getPtr());
 	}
 
+	public boolean isLineString() {
+		return "LineString".equals(getType());
+	}
+
+	public boolean isPolygon() {
+		return "Polygon".equals(getType());
+	}
+
+	public boolean isMultiPoint() {
+		return "MultiPoint".equals(getType());
+	}
+
+	public boolean isMultiLineString() {
+		return "MultiLineString".equals(getType());
+	}
+
+	public boolean isMultiPolygon() {
+		return "MultiPolygon".equals(getType());
+	}
+
+	public boolean isGeometryCollection() {
+		return "GeometryCollection".equals(getType());
+	}
+
+	// ---- readers ----
+
 	public Point2D.Double getPoint() {
 		final double[] coord = getPoint(getPtr());
 		return new Point2D.Double(coord[0], coord[1]);
+	}
+
+	public List<Point2D.Double> getLineString() {
+		return parseLine(coordinates());
+	}
+
+	public List<Point2D.Double> getMultiPoint() {
+		return parseLine(coordinates());
+	}
+
+	/**
+	 * Returns the polygon's rings. The first ring is the exterior boundary; any
+	 * subsequent rings are interior holes.
+	 */
+	public List<List<Point2D.Double>> getPolygon() {
+		return parseRings(coordinates());
+	}
+
+	public List<List<Point2D.Double>> getMultiLineString() {
+		return parseRings(coordinates());
+	}
+
+	public List<List<List<Point2D.Double>>> getMultiPolygon() {
+		final Array polygons = coordinates();
+		final List<List<List<Point2D.Double>>> result = new ArrayList<>(polygons.len());
+		for (int i = 0; i < polygons.len(); i++) {
+			result.add(parseRings(polygons.get(i).getArray()));
+		}
+		return result;
+	}
+
+	public List<Geometry> getGeometryCollection() {
+		final long[] ptrs = getCollection(getPtr());
+		final List<Geometry> result = new ArrayList<>(ptrs.length);
+		for (final long ptr : ptrs) {
+			result.add(new Geometry(ptr));
+		}
+		return result;
+	}
+
+	// ---- factories (x = longitude, y = latitude) ----
+
+	public static Geometry point(double x, double y) {
+		return new Geometry(newPoint(x, y));
+	}
+
+	public static Geometry point(Point2D.Double point) {
+		return new Geometry(newPoint(point.x, point.y));
+	}
+
+	public static Geometry lineString(List<Point2D.Double> points) {
+		return new Geometry(newLineString(flatten(points)));
+	}
+
+	public static Geometry multiPoint(List<Point2D.Double> points) {
+		return new Geometry(newMultiPoint(flatten(points)));
+	}
+
+	/**
+	 * Builds a polygon. The first ring is the exterior boundary; any subsequent
+	 * rings are interior holes.
+	 */
+	public static Geometry polygon(List<List<Point2D.Double>> rings) {
+		return new Geometry(newPolygon(flattenRings(rings)));
+	}
+
+	public static Geometry multiLineString(List<List<Point2D.Double>> lines) {
+		return new Geometry(newMultiLineString(flattenRings(lines)));
+	}
+
+	public static Geometry multiPolygon(List<List<List<Point2D.Double>>> polygons) {
+		final double[][][] data = new double[polygons.size()][][];
+		for (int i = 0; i < polygons.size(); i++) {
+			data[i] = flattenRings(polygons.get(i));
+		}
+		return new Geometry(newMultiPolygon(data));
+	}
+
+	public static Geometry geometryCollection(List<Geometry> geometries) {
+		final long[] ptrs = new long[geometries.size()];
+		for (int i = 0; i < geometries.size(); i++) {
+			ptrs[i] = geometries.get(i).getPtr();
+		}
+		return new Geometry(newCollection(ptrs));
+	}
+
+	// ---- helpers ----
+
+	/** The geometry's coordinates as a nested array of {@code [x, y]} pairs. */
+	private Array coordinates() {
+		return new Value(getCoordinates(getPtr())).getArray();
+	}
+
+	private static Point2D.Double parsePoint(Value coordinate) {
+		final Array xy = coordinate.getArray();
+		return new Point2D.Double(xy.get(0).getDouble(), xy.get(1).getDouble());
+	}
+
+	private static List<Point2D.Double> parseLine(Array line) {
+		final List<Point2D.Double> points = new ArrayList<>(line.len());
+		for (int i = 0; i < line.len(); i++) {
+			points.add(parsePoint(line.get(i)));
+		}
+		return points;
+	}
+
+	private static List<List<Point2D.Double>> parseRings(Array rings) {
+		final List<List<Point2D.Double>> result = new ArrayList<>(rings.len());
+		for (int i = 0; i < rings.len(); i++) {
+			result.add(parseLine(rings.get(i).getArray()));
+		}
+		return result;
+	}
+
+	private static double[] flatten(List<Point2D.Double> points) {
+		final double[] coords = new double[points.size() * 2];
+		for (int i = 0; i < points.size(); i++) {
+			coords[i * 2] = points.get(i).x;
+			coords[i * 2 + 1] = points.get(i).y;
+		}
+		return coords;
+	}
+
+	private static double[][] flattenRings(List<List<Point2D.Double>> rings) {
+		final double[][] data = new double[rings.size()][];
+		for (int i = 0; i < rings.size(); i++) {
+			data[i] = flatten(rings.get(i));
+		}
+		return data;
 	}
 }

--- a/src/main/java/com/surrealdb/ValueBoxing.java
+++ b/src/main/java/com/surrealdb/ValueBoxing.java
@@ -67,6 +67,9 @@ final class ValueBoxing {
 		if (e instanceof com.surrealdb.Object) {
 			return ValueMut.createObject((com.surrealdb.Object) e);
 		}
+		if (e instanceof Geometry) {
+			return ValueMut.createGeometry((Geometry) e);
+		}
 		throw new IllegalArgumentException("unsupported element type " + e.getClass().getName());
 	}
 }

--- a/src/main/java/com/surrealdb/ValueBuilder.java
+++ b/src/main/java/com/surrealdb/ValueBuilder.java
@@ -97,6 +97,9 @@ class ValueBuilder {
 		if (object instanceof Array) {
 			return ValueMut.createArray((Array) object);
 		}
+		if (object instanceof Geometry) {
+			return ValueMut.createGeometry((Geometry) object);
+		}
 		if (object instanceof Object) {
 			return ValueMut.createObject((Object) object);
 		}

--- a/src/main/java/com/surrealdb/ValueMut.java
+++ b/src/main/java/com/surrealdb/ValueMut.java
@@ -36,6 +36,8 @@ public class ValueMut extends Native {
 
 	private static native long newRecordId(long ptr);
 
+	private static native long newGeometry(long ptr);
+
 	private static native long newArray(long ptr);
 
 	private static native long newArrayOf(long[] ptrs);
@@ -94,6 +96,10 @@ public class ValueMut extends Native {
 
 	public static ValueMut createRecordId(RecordId recordId) {
 		return new ValueMut(newRecordId(recordId.getPtr()));
+	}
+
+	public static ValueMut createGeometry(Geometry geometry) {
+		return new ValueMut(newGeometry(geometry.getPtr()));
 	}
 
 	public static ValueMut createArray(Array array) {

--- a/src/main/rust/geometry.rs
+++ b/src/main/rust/geometry.rs
@@ -1,14 +1,89 @@
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ptr::null_mut;
+use std::sync::Arc;
 
 use crate::with_env_body;
-use jni::objects::JClass;
-use jni::sys::{jboolean, jdoubleArray, jint, jlong, jstring};
-use jni::EnvUnowned;
+use geo::{Coord, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
+use jni::objects::{JClass, JDoubleArray, JLongArray, JObjectArray};
+use jni::sys::{jboolean, jdouble, jdoubleArray, jint, jlong, jlongArray, jstring};
+use jni::{Env, EnvUnowned};
 use surrealdb::types::{Geometry, Value};
 
 use crate::error::SurrealError;
-use crate::{get_value_instance, new_double_point, new_string};
+use crate::{
+    get_long_array, get_value_instance, new_double_point, new_jlong_array, new_string,
+    release_instance, JniTypes,
+};
+
+/// Unwraps a `Result` inside a `jlong`-returning native body, surfacing any error
+/// (either a [`SurrealError`] or a `jni::errors::Error`) as a Java exception and
+/// returning `0`. `SurrealError::from` is an identity conversion for `SurrealError`
+/// and converts JNI errors, so this handles both error kinds.
+macro_rules! unwrap_or_throw {
+    ($env:expr, $result:expr) => {
+        match $result {
+            Ok(v) => v,
+            Err(e) => return SurrealError::from(e).exception($env, || 0),
+        }
+    };
+}
+
+/// Reads a flat `double[]` of `[x0, y0, x1, y1, ...]` into a `Vec<Coord<f64>>`.
+fn read_coords(env: &mut Env, arr: JDoubleArray) -> Result<Vec<Coord<f64>>, SurrealError> {
+    let len = arr.len(env)?;
+    let mut buf = vec![0.0_f64; len];
+    arr.get_region(env, 0, &mut buf)?;
+    let mut coords = Vec::with_capacity(len / 2);
+    let mut i = 0;
+    while i + 1 < len {
+        coords.push(Coord {
+            x: buf[i],
+            y: buf[i + 1],
+        });
+        i += 2;
+    }
+    Ok(coords)
+}
+
+/// Reads a `double[][]` (each inner array a flat coordinate list) into a
+/// `Vec<LineString<f64>>` — used for polygon rings and multi-line components.
+fn read_rings(
+    env: &mut Env,
+    arr: JObjectArray<JDoubleArray>,
+) -> Result<Vec<LineString<f64>>, SurrealError> {
+    let len = arr.len(env)?;
+    let mut rings = Vec::with_capacity(len);
+    for i in 0..len {
+        let inner = arr.get_element(env, i)?;
+        rings.push(LineString::new(read_coords(env, inner)?));
+    }
+    Ok(rings)
+}
+
+/// Builds a polygon from its rings: the first ring is the exterior boundary and
+/// any remaining rings are interior holes (matching GeoJSON / `as_coordinates`).
+fn rings_to_polygon(mut rings: Vec<LineString<f64>>) -> Polygon<f64> {
+    if rings.is_empty() {
+        Polygon::new(LineString::new(vec![]), vec![])
+    } else {
+        let exterior = rings.remove(0);
+        Polygon::new(exterior, rings)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Read side: type discrimination + coordinate extraction
+// ---------------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_deleteInstance<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    ptr: jlong,
+) -> jboolean {
+    release_instance::<Arc<Value>>(ptr);
+    true as jboolean
+}
 
 #[no_mangle]
 pub extern "system" fn Java_com_surrealdb_Geometry_isPoint<'local>(
@@ -27,6 +102,21 @@ pub extern "system" fn Java_com_surrealdb_Geometry_isPoint<'local>(
 }
 
 #[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_getType<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    ptr: jlong,
+) -> jstring {
+    with_env_body!(env, env, {
+        let value = get_value_instance!(env, ptr, null_mut);
+        if let Value::Geometry(g) = value.as_ref() {
+            return new_string!(env, g.as_type(), null_mut);
+        }
+        SurrealError::NullPointerException("Geometry").exception(env, null_mut)
+    })
+}
+
+#[no_mangle]
 pub extern "system" fn Java_com_surrealdb_Geometry_getPoint<'local>(
     mut env: EnvUnowned<'local>,
     _class: JClass<'local>,
@@ -40,6 +130,167 @@ pub extern "system" fn Java_com_surrealdb_Geometry_getPoint<'local>(
         SurrealError::NullPointerException("Geometry").exception(env, null_mut)
     })
 }
+
+/// Returns the geometry's coordinates as a nested SurrealDB `Value` (arrays of
+/// `[x, y]` doubles), mirroring GeoJSON nesting. The Java side traverses this with
+/// the existing `Value`/`Array` API. Not used for `GeometryCollection`, whose
+/// per-child types must be preserved — see `getCollection`.
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_getCoordinates<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    ptr: jlong,
+) -> jlong {
+    with_env_body!(env, env, {
+        let value = get_value_instance!(env, ptr, || 0);
+        if let Value::Geometry(g) = value.as_ref() {
+            return JniTypes::new_value(Arc::new(g.as_coordinates()));
+        }
+        SurrealError::NullPointerException("Geometry").exception(env, || 0)
+    })
+}
+
+/// Returns the children of a `GeometryCollection` as an array of `Value` pointers,
+/// each a `Value::Geometry`, so the Java side can wrap them as `Geometry` and keep
+/// each child's own type.
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_getCollection<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    ptr: jlong,
+) -> jlongArray {
+    with_env_body!(env, env, {
+        let value = get_value_instance!(env, ptr, null_mut);
+        if let Value::Geometry(Geometry::Collection(geoms)) = value.as_ref() {
+            let ptrs: Vec<jlong> = geoms
+                .iter()
+                .map(|g| JniTypes::new_value(Arc::new(Value::Geometry(g.clone()))))
+                .collect();
+            return new_jlong_array!(env, &ptrs, null_mut);
+        }
+        SurrealError::NullPointerException("GeometryCollection").exception(env, null_mut)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Write side: construct a Value::Geometry from Java coordinates. Each native
+// returns a pointer to an `Arc<Value>` (a `Value::Geometry`), identical to the
+// read-side representation, so a single `Geometry` Java class serves both and
+// `deleteInstance` releases it the same way.
+// ---------------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_newPoint<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    x: jdouble,
+    y: jdouble,
+) -> jlong {
+    JniTypes::new_value(Arc::new(Value::Geometry(Geometry::Point(Point::new(x, y)))))
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_newLineString<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    coords: JDoubleArray<'local>,
+) -> jlong {
+    with_env_body!(env, env, {
+        let coords = unwrap_or_throw!(env, read_coords(env, coords));
+        JniTypes::new_value(Arc::new(Value::Geometry(Geometry::Line(LineString::new(
+            coords,
+        )))))
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_newMultiPoint<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    coords: JDoubleArray<'local>,
+) -> jlong {
+    with_env_body!(env, env, {
+        let coords = unwrap_or_throw!(env, read_coords(env, coords));
+        let points: Vec<Point<f64>> = coords.into_iter().map(Point::from).collect();
+        JniTypes::new_value(Arc::new(Value::Geometry(Geometry::MultiPoint(
+            MultiPoint::new(points),
+        ))))
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_newPolygon<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    rings: JObjectArray<'local, JDoubleArray<'local>>,
+) -> jlong {
+    with_env_body!(env, env, {
+        let rings = unwrap_or_throw!(env, read_rings(env, rings));
+        JniTypes::new_value(Arc::new(Value::Geometry(Geometry::Polygon(
+            rings_to_polygon(rings),
+        ))))
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_newMultiLineString<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    lines: JObjectArray<'local, JDoubleArray<'local>>,
+) -> jlong {
+    with_env_body!(env, env, {
+        let lines = unwrap_or_throw!(env, read_rings(env, lines));
+        JniTypes::new_value(Arc::new(Value::Geometry(Geometry::MultiLine(
+            MultiLineString::new(lines),
+        ))))
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_newMultiPolygon<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    polygons: JObjectArray<'local, JObjectArray<'local, JDoubleArray<'local>>>,
+) -> jlong {
+    with_env_body!(env, env, {
+        let len = unwrap_or_throw!(env, polygons.len(env));
+        let mut polys = Vec::with_capacity(len);
+        for i in 0..len {
+            let rings_arr = unwrap_or_throw!(env, polygons.get_element(env, i));
+            let rings = unwrap_or_throw!(env, read_rings(env, rings_arr));
+            polys.push(rings_to_polygon(rings));
+        }
+        JniTypes::new_value(Arc::new(Value::Geometry(Geometry::MultiPolygon(
+            MultiPolygon::new(polys),
+        ))))
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_surrealdb_Geometry_newCollection<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    ptrs: JLongArray<'local>,
+) -> jlong {
+    with_env_body!(env, env, {
+        let ptrs = get_long_array!(env, &ptrs, || 0);
+        let mut geoms = Vec::with_capacity(ptrs.len());
+        for p in ptrs {
+            let value = get_value_instance!(env, p, || 0);
+            if let Value::Geometry(g) = value.as_ref() {
+                geoms.push(g.clone());
+            } else {
+                return SurrealError::NullPointerException("Geometry").exception(env, || 0);
+            }
+        }
+        JniTypes::new_value(Arc::new(Value::Geometry(Geometry::Collection(geoms))))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Object identity (equals / hashCode / toString) — delegated to the SDK's
+// `Geometry` impls, which already cover every variant.
+// ---------------------------------------------------------------------------
 
 #[no_mangle]
 pub extern "system" fn Java_com_surrealdb_Geometry_equals<'local>(

--- a/src/main/rust/valuemut.rs
+++ b/src/main/rust/valuemut.rs
@@ -186,6 +186,22 @@ pub extern "system" fn Java_com_surrealdb_ValueMut_newRecordId<'local>(
 }
 
 #[no_mangle]
+pub extern "system" fn Java_com_surrealdb_ValueMut_newGeometry<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    ptr: jlong,
+) -> jlong {
+    with_env_body!(env, env, {
+        let value = get_value_instance!(env, ptr, || 0);
+        if matches!(value.as_ref(), Value::Geometry(_)) {
+            // Clone (not move) so the Java Geometry stays valid and reusable.
+            return JniTypes::new_value_mut(value.as_ref().clone());
+        }
+        SurrealError::NullPointerException("Geometry").exception(env, || 0)
+    })
+}
+
+#[no_mangle]
 pub extern "system" fn Java_com_surrealdb_ValueMut_newArray<'local>(
     mut env: EnvUnowned<'local>,
     _class: JClass<'local>,

--- a/src/test/java/com/surrealdb/QueryTests.java
+++ b/src/test/java/com/surrealdb/QueryTests.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -217,6 +219,195 @@ public class QueryTests {
 							rowObject.get("pt").getGeometry().getPoint());
 				}
 			}
+		}
+	}
+
+	// Reads a geometry literal of the given SurrealQL subtype directly via RETURN.
+	private static Geometry literalGeometry(Surreal surreal, String subType, String geoJson) {
+		final Value value = surreal.query("RETURN <geometry<" + subType + ">> " + geoJson).take(0);
+		assertTrue(value.isGeometry());
+		return value.getGeometry();
+	}
+
+	@Test
+	void queryGeometryLineString() throws SurrealException {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Geometry g = literalGeometry(surreal, "line",
+					"{ type: \"LineString\", coordinates: [[0, 0], [1, 1], [2, 0]] }");
+			assertEquals("LineString", g.getType());
+			assertTrue(g.isLineString());
+			assertEquals(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1), new Point2D.Double(2, 0)),
+					g.getLineString());
+		}
+	}
+
+	@Test
+	void queryGeometryPolygon() throws SurrealException {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			// Exterior ring + one interior hole.
+			final Geometry g = literalGeometry(surreal, "polygon",
+					"{ type: \"Polygon\", coordinates: ["
+							+ "[[0, 0], [4, 0], [4, 4], [0, 4], [0, 0]], "
+							+ "[[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]" + "] }");
+			assertEquals("Polygon", g.getType());
+			assertTrue(g.isPolygon());
+			final List<List<Point2D.Double>> rings = g.getPolygon();
+			assertEquals(2, rings.size());
+			assertEquals(new Point2D.Double(0, 0), rings.get(0).get(0));
+			assertEquals(new Point2D.Double(1, 1), rings.get(1).get(0));
+		}
+	}
+
+	@Test
+	void queryGeometryMultiPoint() throws SurrealException {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Geometry g = literalGeometry(surreal, "multipoint",
+					"{ type: \"MultiPoint\", coordinates: [[0, 0], [1, 1]] }");
+			assertEquals("MultiPoint", g.getType());
+			assertTrue(g.isMultiPoint());
+			assertEquals(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)), g.getMultiPoint());
+		}
+	}
+
+	@Test
+	void queryGeometryMultiLineString() throws SurrealException {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Geometry g = literalGeometry(surreal, "multiline",
+					"{ type: \"MultiLineString\", coordinates: [[[0, 0], [1, 1]], [[2, 2], [3, 3]]] }");
+			assertEquals("MultiLineString", g.getType());
+			assertTrue(g.isMultiLineString());
+			final List<List<Point2D.Double>> lines = g.getMultiLineString();
+			assertEquals(2, lines.size());
+			assertEquals(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)), lines.get(0));
+			assertEquals(Arrays.asList(new Point2D.Double(2, 2), new Point2D.Double(3, 3)), lines.get(1));
+		}
+	}
+
+	@Test
+	void queryGeometryMultiPolygon() throws SurrealException {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Geometry g = literalGeometry(surreal, "multipolygon",
+					"{ type: \"MultiPolygon\", coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]] }");
+			assertEquals("MultiPolygon", g.getType());
+			assertTrue(g.isMultiPolygon());
+			final List<List<List<Point2D.Double>>> polys = g.getMultiPolygon();
+			assertEquals(1, polys.size());
+			assertEquals(1, polys.get(0).size());
+			assertEquals(new Point2D.Double(0, 0), polys.get(0).get(0).get(0));
+		}
+	}
+
+	@Test
+	void queryGeometryCollection() throws SurrealException {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Geometry g = literalGeometry(surreal, "collection",
+					"{ type: \"GeometryCollection\", geometries: ["
+							+ "{ type: \"Point\", coordinates: [0, 0] }, "
+							+ "{ type: \"LineString\", coordinates: [[1, 1], [2, 2]] }" + "] }");
+			assertEquals("GeometryCollection", g.getType());
+			assertTrue(g.isGeometryCollection());
+			final List<Geometry> children = g.getGeometryCollection();
+			assertEquals(2, children.size());
+			assertTrue(children.get(0).isPoint());
+			assertEquals(new Point2D.Double(0, 0), children.get(0).getPoint());
+			assertTrue(children.get(1).isLineString());
+			assertEquals(Arrays.asList(new Point2D.Double(1, 1), new Point2D.Double(2, 2)),
+					children.get(1).getLineString());
+		}
+	}
+
+	// Stores a geometry via a bound parameter and reads it back from the database.
+	private static Geometry roundTripBoundParam(Surreal surreal, Geometry geometry) {
+		final Map<String, java.lang.Object> params = new HashMap<>();
+		params.put("g", geometry);
+		surreal.query("UPSERT geo:1 SET shape = $g", params);
+		return surreal.query("SELECT VALUE shape FROM geo:1").take(0).getArray().get(0).getGeometry();
+	}
+
+	@Test
+	void geometryRoundTripViaBoundParam() throws SurrealException {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+
+			final Geometry point = Geometry.point(1.5, 2.5);
+			assertEquals(point, roundTripBoundParam(surreal, point));
+
+			final Geometry line = Geometry.lineString(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)));
+			final Geometry lineRead = roundTripBoundParam(surreal, line);
+			assertEquals("LineString", lineRead.getType());
+			assertEquals(line, lineRead);
+			assertEquals(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)), lineRead.getLineString());
+
+			final Geometry polygon = Geometry.polygon(Collections.singletonList(Arrays.asList(
+					new Point2D.Double(0, 0), new Point2D.Double(4, 0), new Point2D.Double(4, 4),
+					new Point2D.Double(0, 4), new Point2D.Double(0, 0))));
+			assertEquals(polygon, roundTripBoundParam(surreal, polygon));
+
+			final Geometry multiPoint = Geometry.multiPoint(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)));
+			assertEquals(multiPoint, roundTripBoundParam(surreal, multiPoint));
+
+			final Geometry multiLine = Geometry.multiLineString(Arrays.asList(
+					Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)),
+					Arrays.asList(new Point2D.Double(2, 2), new Point2D.Double(3, 3))));
+			assertEquals(multiLine, roundTripBoundParam(surreal, multiLine));
+
+			final Geometry multiPolygon = Geometry.multiPolygon(Collections.singletonList(Collections.singletonList(
+					Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 0), new Point2D.Double(1, 1),
+							new Point2D.Double(0, 1), new Point2D.Double(0, 0)))));
+			final Geometry multiPolygonRead = roundTripBoundParam(surreal, multiPolygon);
+			assertEquals("MultiPolygon", multiPolygonRead.getType());
+			assertEquals(multiPolygon, multiPolygonRead);
+			assertEquals(new Point2D.Double(0, 0), multiPolygonRead.getMultiPolygon().get(0).get(0).get(0));
+		}
+	}
+
+	@Test
+	void geometryRoundTripViaContent() throws SurrealException {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			// Polygon with a hole, stored as a field of a created record (exercises the
+			// Map content path in ValueBuilder).
+			final Geometry polygon = Geometry.polygon(Arrays.asList(
+					Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(4, 0), new Point2D.Double(4, 4),
+							new Point2D.Double(0, 4), new Point2D.Double(0, 0)),
+					Arrays.asList(new Point2D.Double(1, 1), new Point2D.Double(2, 1), new Point2D.Double(2, 2),
+							new Point2D.Double(1, 2), new Point2D.Double(1, 1))));
+			final Map<String, java.lang.Object> content = new HashMap<>();
+			content.put("area", polygon);
+			surreal.create(new RecordId("place", 1), content);
+
+			final Value row = surreal.select(new RecordId("place", 1)).get();
+			final Geometry read = row.getObject().get("area").getGeometry();
+			assertEquals("Polygon", read.getType());
+			assertEquals(2, read.getPolygon().size());
+			assertEquals(polygon, read);
+		}
+	}
+
+	@Test
+	void geometryCollectionRoundTrip() throws SurrealException {
+		try (final Surreal surreal = new Surreal()) {
+			surreal.connect("memory").useNs("test_ns").useDb("test_db");
+			final Geometry point = Geometry.point(1, 2);
+			final Geometry line = Geometry.lineString(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)));
+			final Geometry inner = Geometry.geometryCollection(Arrays.asList(point, line));
+			// A collection nested inside another collection.
+			final Geometry nested = Geometry.geometryCollection(Arrays.asList(point, inner));
+
+			final Geometry read = roundTripBoundParam(surreal, nested);
+			assertEquals("GeometryCollection", read.getType());
+			final List<Geometry> children = read.getGeometryCollection();
+			assertEquals(2, children.size());
+			assertTrue(children.get(0).isPoint());
+			assertTrue(children.get(1).isGeometryCollection());
+			assertEquals(2, children.get(1).getGeometryCollection().size());
+			assertEquals(nested, read);
 		}
 	}
 

--- a/src/test/java/com/surrealdb/QueryTests.java
+++ b/src/test/java/com/surrealdb/QueryTests.java
@@ -248,8 +248,7 @@ public class QueryTests {
 			surreal.connect("memory").useNs("test_ns").useDb("test_db");
 			// Exterior ring + one interior hole.
 			final Geometry g = literalGeometry(surreal, "polygon",
-					"{ type: \"Polygon\", coordinates: ["
-							+ "[[0, 0], [4, 0], [4, 4], [0, 4], [0, 0]], "
+					"{ type: \"Polygon\", coordinates: [" + "[[0, 0], [4, 0], [4, 4], [0, 4], [0, 0]], "
 							+ "[[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]" + "] }");
 			assertEquals("Polygon", g.getType());
 			assertTrue(g.isPolygon());
@@ -307,8 +306,7 @@ public class QueryTests {
 		try (final Surreal surreal = new Surreal()) {
 			surreal.connect("memory").useNs("test_ns").useDb("test_db");
 			final Geometry g = literalGeometry(surreal, "collection",
-					"{ type: \"GeometryCollection\", geometries: ["
-							+ "{ type: \"Point\", coordinates: [0, 0] }, "
+					"{ type: \"GeometryCollection\", geometries: [" + "{ type: \"Point\", coordinates: [0, 0] }, "
 							+ "{ type: \"LineString\", coordinates: [[1, 1], [2, 2]] }" + "] }");
 			assertEquals("GeometryCollection", g.getType());
 			assertTrue(g.isGeometryCollection());
@@ -338,28 +336,30 @@ public class QueryTests {
 			final Geometry point = Geometry.point(1.5, 2.5);
 			assertEquals(point, roundTripBoundParam(surreal, point));
 
-			final Geometry line = Geometry.lineString(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)));
+			final Geometry line = Geometry
+					.lineString(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)));
 			final Geometry lineRead = roundTripBoundParam(surreal, line);
 			assertEquals("LineString", lineRead.getType());
 			assertEquals(line, lineRead);
 			assertEquals(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)), lineRead.getLineString());
 
-			final Geometry polygon = Geometry.polygon(Collections.singletonList(Arrays.asList(
-					new Point2D.Double(0, 0), new Point2D.Double(4, 0), new Point2D.Double(4, 4),
-					new Point2D.Double(0, 4), new Point2D.Double(0, 0))));
+			final Geometry polygon = Geometry
+					.polygon(Collections.singletonList(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(4, 0),
+							new Point2D.Double(4, 4), new Point2D.Double(0, 4), new Point2D.Double(0, 0))));
 			assertEquals(polygon, roundTripBoundParam(surreal, polygon));
 
-			final Geometry multiPoint = Geometry.multiPoint(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)));
+			final Geometry multiPoint = Geometry
+					.multiPoint(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)));
 			assertEquals(multiPoint, roundTripBoundParam(surreal, multiPoint));
 
-			final Geometry multiLine = Geometry.multiLineString(Arrays.asList(
-					Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)),
-					Arrays.asList(new Point2D.Double(2, 2), new Point2D.Double(3, 3))));
+			final Geometry multiLine = Geometry
+					.multiLineString(Arrays.asList(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)),
+							Arrays.asList(new Point2D.Double(2, 2), new Point2D.Double(3, 3))));
 			assertEquals(multiLine, roundTripBoundParam(surreal, multiLine));
 
-			final Geometry multiPolygon = Geometry.multiPolygon(Collections.singletonList(Collections.singletonList(
-					Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 0), new Point2D.Double(1, 1),
-							new Point2D.Double(0, 1), new Point2D.Double(0, 0)))));
+			final Geometry multiPolygon = Geometry.multiPolygon(Collections.singletonList(
+					Collections.singletonList(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 0),
+							new Point2D.Double(1, 1), new Point2D.Double(0, 1), new Point2D.Double(0, 0)))));
 			final Geometry multiPolygonRead = roundTripBoundParam(surreal, multiPolygon);
 			assertEquals("MultiPolygon", multiPolygonRead.getType());
 			assertEquals(multiPolygon, multiPolygonRead);
@@ -395,7 +395,8 @@ public class QueryTests {
 		try (final Surreal surreal = new Surreal()) {
 			surreal.connect("memory").useNs("test_ns").useDb("test_db");
 			final Geometry point = Geometry.point(1, 2);
-			final Geometry line = Geometry.lineString(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)));
+			final Geometry line = Geometry
+					.lineString(Arrays.asList(new Point2D.Double(0, 0), new Point2D.Double(1, 1)));
 			final Geometry inner = Geometry.geometryCollection(Arrays.asList(point, line));
 			// A collection nested inside another collection.
 			final Geometry nested = Geometry.geometryCollection(Arrays.asList(point, inner));


### PR DESCRIPTION
## Summary

Resolves #99. The README's "Planned Features" listed *"All Geometry types (actually only points)"* — this PR delivers the feature instead of just rewording it.

Extends `Geometry` from Point-only / read-only to **all seven geometry types, read + write**: Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, and GeometryCollection.

## Public API (`Geometry`)

- **Type discrimination:** `getType()` → `"Point" | "LineString" | … | "GeometryCollection"`, plus `isLineString()` / `isPolygon()` / `isMultiPoint()` / `isMultiLineString()` / `isMultiPolygon()` / `isGeometryCollection()`. Existing `isPoint()` / `getPoint()` are unchanged.
- **Readers:** `getLineString()`, `getMultiPoint()` → `List<Point2D.Double>`; `getPolygon()`, `getMultiLineString()` → `List<List<Point2D.Double>>` (polygon ring 0 = exterior, the rest are holes); `getMultiPolygon()` → `List<List<List<Point2D.Double>>>`; `getGeometryCollection()` → `List<Geometry>`.
- **Factories:** `point`, `lineString`, `polygon`, `multiPoint`, `multiLineString`, `multiPolygon`, `geometryCollection`. Geometries now serialize through `create` / `update` content and bound params (wired via `ValueMut` / `ValueBuilder` / `ValueBoxing`).

Coordinates use `java.awt.geom.Point2D.Double`, where `x` is the longitude and `y` is the latitude.

## Implementation notes

- **Reads** reuse the SDK's `Geometry::as_coordinates()` and the existing `Value` / `Array` traversal (coordinates decode as `getDouble()`), keeping the new Rust surface small. `GeometryCollection` returns child `Geometry` pointers so each child keeps its own type.
- **Writes** build `geo` types directly via `Geometry::from_*`. Adds `geo = "0.32"` — the exact version `surrealdb-types` uses, so the `geo::*` types unify with `surrealdb::types::Geometry`.

## Bug fix

`Geometry` declared a `deleteInstance` native with **no matching Rust symbol** — finalizing any `Geometry` would have thrown `UnsatisfiedLinkError` and leaked the `Arc<Value>`. Added `Java_com_surrealdb_Geometry_deleteInstance`.

## Tests

New tests in `QueryTests`: literal reads for each of the seven types, plus write round-trips via a bound parameter, via `create(RecordId, Map content)`, and a nested `GeometryCollection`. Full suite green locally (`cargo build`, `cargo clippy`, `./gradlew test`).
