### PR TITLE
Bump SurrealDB to 3.1.5, run CI against server v3.1.5

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -310,7 +310,7 @@ jobs:
       - name: Start SurrealDB
         uses: surrealdb/setup-surreal@7c103070ba4f544240cd287432ba70d6f50163a5 # v2
         with:
-          surrealdb_version: v3.1.3
+          surrealdb_version: v3.1.5
           surrealdb_port: 8000
           surrealdb_auth: false
           surrealdb_strict: false
@@ -355,7 +355,7 @@ jobs:
         if: runner.os != 'Windows'
         uses: surrealdb/setup-surreal@7c103070ba4f544240cd287432ba70d6f50163a5 # v2
         with:
-          surrealdb_version: v3.1.3
+          surrealdb_version: v3.1.5
           surrealdb_port: 8000
           surrealdb_auth: false
           surrealdb_strict: false

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Start SurrealDB
         uses: surrealdb/setup-surreal@7c103070ba4f544240cd287432ba70d6f50163a5 # v2
         with:
-          surrealdb_version: v3.1.3
+          surrealdb_version: v3.1.5
           surrealdb_port: 8000
           surrealdb_auth: false
           surrealdb_strict: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Start SurrealDB
         uses: surrealdb/setup-surreal@7c103070ba4f544240cd287432ba70d6f50163a5 # v2
         with:
-          surrealdb_version: v3.1.3
+          surrealdb_version: v3.1.5
           surrealdb_port: 8000
           surrealdb_auth: false
           surrealdb_strict: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+- Upgrade to SurrealDB SDK 3.1.5 [#185](https://github.com/surrealdb/surrealdb.java/pull/185).
+- Run CI against SurrealDB server v3.1.5, matching the embedded SDK; previously v3.1.3 [#185](https://github.com/surrealdb/surrealdb.java/pull/185).
+- Align the declared `tokio` (1.52.1) and `rust_decimal` (1.41.0) minimums in `Cargo.toml` with SurrealDB 3.1.5's workspace; resolved lockfile versions are unchanged [#185](https://github.com/surrealdb/surrealdb.java/pull/185).
 
 ## [2.1.1] - 2026-06-10
 - Support more Java datetime types in value conversion: `Instant`, `OffsetDateTime`, `LocalDateTime` (interpreted as UTC), `java.util.Date`, and the `java.sql` date types, in query bindings, `Array.of()`/`Id.from()`, and POJO/record round trips [#172](https://github.com/surrealdb/surrealdb.java/pull/172).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3957,9 +3957,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9deae5add485b4b5492f9f1a05500e24e4ad272896547835e0c9696b44d05b"
+checksum = "81ee3110fe3ab8172eb8c135c96ed2d57c7470cdf1ad732d176db95a92c9faab"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3995,9 +3995,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-collections"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e09c94ab7abc679f18b47367d70db7ee902553f4fec4fb0a9c92286938abc3"
+checksum = "069e0c90dad71cf8f17475f75118a56ad3047f2f46fac24643e562b415b3f11a"
 dependencies = [
  "revision",
  "storekey",
@@ -4005,9 +4005,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3097d6247661f5c5a319fa1f4683d5beba2956c6b86615ad69b55f988ab135b"
+checksum = "9780c2f3dd6a3cb1cce8ca7c866b5e82ac4377b826a09bf718ca441bfd2bd747"
 dependencies = [
  "addr",
  "affinitypool",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-java"
-version = "3.1.4"
+version = "3.1.5"
 dependencies = [
  "async-channel",
  "cargo-lock",
@@ -4148,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-strand"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef42225a4fe1f281b52520ee6042ce1545ffbeae2431034635662538efad740"
+checksum = "4af300a172983b23c05e692cacba462ca023e3e9404812b6783d09a8af487865"
 dependencies = [
  "revision",
  "serde",
@@ -4159,9 +4159,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b03150b36ee46f24cc2dbb22659426c42661ea484769d6345ebb3542e88fa7"
+checksum = "edd434d643c040c2872c9cfc88c90e9910e9a55456d2df7e68e92725225d3e20"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4190,9 +4190,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023873912963cb7cd58b5d158f68081af629dba13236152f96a4cff8b3dd3fc6"
+checksum = "16d385184f3b727c58c4d099a877a4c54ffe879dd190396cc80b1676146b8b2b"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-java"
-version = "3.1.4"
+version = "3.1.5"
 authors = ["Emmanuel Keller <emmanuel.keller@surrealdb.com>"]
 edition = "2021"
 
@@ -19,14 +19,14 @@ opt-level = 3
 # Driver-specific dependencies (jni, once_cell, cargo-lock) are independent.
 [dependencies]
 jni = "0.22.4"
-surrealdb = { version = "3.1.4", default-features = false, features = ["rustls", "protocol-http", "protocol-ws"] }
+surrealdb = { version = "3.1.5", default-features = false, features = ["rustls", "protocol-http", "protocol-ws"] }
 # Geometry construction (write path). Must match the geo version surrealdb-types uses
 # so the geo::* types unify with surrealdb::types::Geometry's inner geo types.
 geo = { version = "0.32", default-features = false }
 serde = "1.0.228"
 serde_json = "1.0.149"
-rust_decimal = "1.40.0"
-tokio = "1.49.0"
+rust_decimal = "1.41.0"
+tokio = "1.52.1"
 parking_lot = "0.12.5"
 once_cell = "1.21.4"
 chrono = "0.4.44"


### PR DESCRIPTION
## Summary
Upgrades the embedded SurrealDB SDK from **3.1.4 → 3.1.5** (latest 3.1.x, released 2026-06-19) and aligns CI with it.

## Changes
- **`Cargo.toml` / `Cargo.lock`** — embedded `surrealdb` crate and the mirrored `[package].version` 3.1.4 → 3.1.5, via `cargo update -p surrealdb --precise 3.1.5`. The lockfile diff is limited to the `surrealdb*` crate family (7 crates); 103 other deps unchanged.
- **CI** — `surrealdb_version` v3.1.3 → v3.1.5 in `test.yml`, `reports.yml`, and `cross.yml` (4 jobs), matching the embedded SDK. v3.1.5 shipped as a public server release the same day, so this closes the prior crate/server skew (CI was on v3.1.3 against crate 3.1.4).
- **Shared-dep alignment** — declared `tokio` (1.49.0 → 1.52.1) and `rust_decimal` (1.40.0 → 1.41.0) minimums now match SurrealDB 3.1.5's workspace `Cargo.toml`, per the convention in `Cargo.toml`. The lockfile already resolved these higher (tokio 1.52.3, rust_decimal 1.42.0), so **resolved versions are unchanged** — this only trues up the declared floors that had drifted since 3.1.4.

## Verification
- `cargo check` clean on the pinned 1.95 toolchain; **no JNI binding changes** required.
- Rust toolchain unchanged at 1.95 (still 3.1.x).
- Full test suite runs in CI against SurrealDB server v3.1.5.