### PR TITLE
Prepare release 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [Unreleased]
+## [2.1.2] - 2026-06-24
+- Add full geometry-type support for reading and writing all seven types — Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, and GeometryCollection — via `Geometry` type-discrimination accessors (`getType()`, `isPolygon()`, …), readers returning `java.awt.geom.Point2D.Double` coordinates (x = longitude, y = latitude), and factory methods that serialize through `create`/`update` content and bound parameters. Also fixes an `UnsatisfiedLinkError` thrown when a `Geometry` was finalized (the native `deleteInstance` had no matching Rust symbol) [#183](https://github.com/surrealdb/surrealdb.java/pull/183).
+- Add `Surreal.kill(String)` / `Surreal.kill(java.util.UUID)` to terminate a live query by id, and `LiveStream.getQueryId()` to read the live-query UUID immediately, before the first notification; `selectLive` now starts the subscription through the public `LIVE SELECT` query path so the id is available up front. `kill()` stops notifications but does not close a local `LiveStream` — use `LiveStream.close()` to release a blocked `next()` [#184](https://github.com/surrealdb/surrealdb.java/pull/184).
 - Upgrade to SurrealDB SDK 3.1.5 [#185](https://github.com/surrealdb/surrealdb.java/pull/185).
 - Run CI against SurrealDB server v3.1.5, matching the embedded SDK; previously v3.1.3 [#185](https://github.com/surrealdb/surrealdb.java/pull/185).
 - Align the declared `tokio` (1.52.1) and `rust_decimal` (1.41.0) minimums in `Cargo.toml` with SurrealDB 3.1.5's workspace; resolved lockfile versions are unchanged [#185](https://github.com/surrealdb/surrealdb.java/pull/185).

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Gradle:
 
 ```groovy
 ext {
-    surrealdbVersion = "2.1.1"
+    surrealdbVersion = "2.1.2"
 }
 
 dependencies {
@@ -86,7 +86,7 @@ Maven:
 <dependency>
     <groupId>com.surrealdb</groupId>
     <artifactId>surrealdb</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
 }
 
 group 'com.surrealdb'
-version '2.1.2-SNAPSHOT'
+version '2.1.2'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Release **2.1.2**. Sets the release version in `build.gradle` and the README stable-install example, dates the CHANGELOG section, and backfills the changelog entries for #183 and #184 (both landed on `main` without one).

### Included since 2.1.1
- **#183** — Full geometry-type support (read + write): all seven types, type-discrimination accessors, `Point2D.Double` readers, and write factories. Also fixes an `UnsatisfiedLinkError` on `Geometry` finalization.
- **#184** — Live-query `kill()` (`Surreal.kill(String)` / `kill(UUID)`) and `LiveStream.getQueryId()` exposing the live-query UUID up front.
- **#185** — Upgrade to SurrealDB SDK 3.1.5; CI runs against server v3.1.5.

### Release mechanics
- Pushing this non-SNAPSHOT version to `main` does **not** auto-publish (the publish job skips non-SNAPSHOT pushes); the release is published via manual `workflow_dispatch` after merge.
- Follow-up PR will bump `main` to `2.1.3-SNAPSHOT`.